### PR TITLE
Update downloader.py

### DIFF
--- a/conductor/tools/downloader.py
+++ b/conductor/tools/downloader.py
@@ -123,7 +123,7 @@ class Download(object):
 
 
                             self.set_download_status(download_id,'downloading')
-                            download_file = open(local_path, 'w')
+                            download_file = open(local_path, 'wb')
                             tick = time.time()
                             while 1:
                                 if (time.time() - tick) > 60:


### PR DESCRIPTION
by default, python inserts windows type newlines to files that are downloaded as per the docs:

https://docs.python.org/2/tutorial/inputoutput.html#reading-and-writing-files
http://stackoverflow.com/questions/11847992/python-downloading-zip-files-damaged