### PR TITLE
Cr-462

### DIFF
--- a/conductor/lib/common.py
+++ b/conductor/lib/common.py
@@ -509,7 +509,7 @@ class Config():
             possible_paths = [x for x in os.environ['CONDUCTOR_CONFIG'].split(path_separator) if len(x) > 0]
             if len(possible_paths) > 0:
                 return possible_paths
-        return [os.path.join(base_dir(), 'example_config', 'config.yml')]  # This is for when CONDUCTOR_CONFIG variable is empty.
+        return [os.path.join(base_dir(), 'example_config', 'config.default.yml')]  # This is for when CONDUCTOR_CONFIG variable is empty.
 
     def get_user_config(self):
         config_files = self.get_config_file_paths()

--- a/conductor/lib/common.py
+++ b/conductor/lib/common.py
@@ -509,15 +509,7 @@ class Config():
             possible_paths = [x for x in os.environ['CONDUCTOR_CONFIG'].split(path_separator) if len(x) > 0]
             if len(possible_paths) > 0:
                 return possible_paths
-        return [os.path.join(base_dir(), 'config.yml')]  # This is for when CONDUCTOR_CONFIG variable is empty.
-
-    def create_default_config(self, path):
-        if not os.path.exists(os.path.dirname(path)):
-            os.makedirs(os.path.dirname(path))
-        with open(path, 'w') as config:
-            config.write('local_upload: True\n')
-            config.write('# api_key_path: <path to conductor_api_key.json>\n')
-        return {}
+        return [os.path.join(base_dir(), 'example_config', 'config.yml')]  # This is for when CONDUCTOR_CONFIG variable is empty.
 
     def get_user_config(self):
         config_files = self.get_config_file_paths()
@@ -544,8 +536,8 @@ class Config():
                     logger.error(message)
             else:
                 logger.warn('Config filepath: %s does not point to a file', config_file)
-        logger.warn('No valid config files found, creating default config.yml at {}'.format(config_files[-1]))
-        return self.create_default_config(config_files[-1])
+        logger.warn('No valid config files found')  # It should never reach this line
+        return {}
 
     def verify_required_params(self, config):
         logger.debug('config is %s' % config)

--- a/installers/example_config/config.default.yml
+++ b/installers/example_config/config.default.yml
@@ -1,0 +1,2 @@
+local_upload: true
+#api_key_path: <path to conductor_api_key.json>

--- a/installers/osx/build.sh
+++ b/installers/osx/build.sh
@@ -19,6 +19,7 @@ cp -r ../../bin \
       ../../nuke_menu \
       ../../clarisse_shelf \
       ./python \
+      ../example_config \
       build/root/Applications/Conductor.app/Contents/MacOS
 cp setenv build/root/Applications/Conductor.app/Contents/MacOS
 cp Conductor.icns build/root/Applications/Conductor.app/Contents/Resources

--- a/installers/rpm/build.sh
+++ b/installers/rpm/build.sh
@@ -12,6 +12,7 @@ cp -r ../../bin \
       ../../maya_shelf \
       ../../nuke_menu \
       ../../clarisse_shelf \
+      ../example_config \
        build/BUILDROOT/${VERSION}/opt/conductor
 
 cp conductor.spec build/SPECS

--- a/installers/windows/build.sh
+++ b/installers/windows/build.sh
@@ -3,7 +3,7 @@ pushd $( dirname "${BASH_SOURCE[0]}" )
 PATH=$PATH:./nsis/bin
 
 mkdir -p ./Conductor
-cp -r ../../bin ../../conductor ../../maya_shelf ../../nuke_menu ../../clarisse_shelf ./python ./conductor.bat ./Conductor
+cp -r ../../bin ../../conductor ../../maya_shelf ../../nuke_menu ../../clarisse_shelf ../example_config ./python ./conductor.bat ./Conductor
 
 makensis -DVERSION="${RELEASE_VERSION:1}.0" -DINSTALLER_NAME="conductor-${RELEASE_VERSION}.exe" ConductorClient.nsi
 


### PR DESCRIPTION
Installer now copies default config into `Conductor Technolgies/example_config` and uses that to read if no user-provided config is available. Documentation will need to be updated