### PR TITLE
CR-1052 config path change alert

### DIFF
--- a/installers/windows/ConductorClient.nsi
+++ b/installers/windows/ConductorClient.nsi
@@ -103,7 +103,7 @@ SectionEnd
 ######################################################################
 
 Function .onInstSuccess
-    MessageBox MB_OK "Conductor now checks C:\Users\<username>\AppData\Roaming\Conductor Technologies\Conductor\config.yml. If you already use a config.yml please move it to this location to avoid any conflicts"
+    MessageBox MB_OK "Conductor now checks C:\Users\<username>\AppData\Roaming\Conductor Technologies\Conductor\config.yml as the default location for a config file. If you already use a config.yml please move it to this location to avoid any conflicts"
 FunctionEnd
 
 ######################################################################

--- a/installers/windows/ConductorClient.nsi
+++ b/installers/windows/ConductorClient.nsi
@@ -102,6 +102,12 @@ SectionEnd
 
 ######################################################################
 
+Function .onInstSuccess
+    MessageBox MB_OK "Conductor now checks C:\Users\<username>\AppData\Roaming\Conductor Technologies\Conductor\config.yml. If you already use a config.yml please move it to this location to avoid any conflicts"
+FunctionEnd
+
+######################################################################
+
 Section Uninstall
 ${INSTALL_TYPE}
 


### PR DESCRIPTION
Popup message box alerts Windows users that config file path has changed here's the message:

`Conductor now checks C:\Users\<username>\AppData\Roaming\Conductor Technologies\Conductor\config.yml as the default location for a config file. If you already use a config.yml please move it to this location to avoid any conflicts`