### PR TITLE
added fix for os.path.splitdrive to Nuke submitter

### DIFF
--- a/conductor/submitter_nuke.py
+++ b/conductor/submitter_nuke.py
@@ -159,8 +159,8 @@ class NukeConductorSubmitter(submitter.ConductorSubmitter):
 
         # Strip the lettered drive from the filepath (if one exists).
         # This is a hack to allow a Windows filepath to be properly used
-        # as an argument in a linux shell command on the backend. Not pretty.
-        nuke_filepath_nodrive = os.path.splitdrive(nuke_scriptpath)[-1]
+        # as an argument in a linux shell on the backend. Not pretty.
+        nuke_filepath_nodrive = file_utils.strip_drive_letter(nuke_scriptpath)
 
         chunk_size = self.getChunkSize()
         frames_str = self.getFrameRangeString()


### PR DESCRIPTION
- fixed drive letter stripping bug due to changes in ntpath.splitdrive
between python 2.7.6 and 2.7.11
-see original fix here: 61193c8fb6fd52fe95eab334e1bcee339bfe4225