### PR TITLE
Pt-243 MtoA 2.1.0.2, PT-210

### DIFF
--- a/conductor/resources/resources.yml
+++ b/conductor/resources/resources.yml
@@ -327,6 +327,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -399,6 +400,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -470,6 +472,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -542,6 +545,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -614,6 +618,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -686,6 +691,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -758,6 +764,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -830,6 +837,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -902,6 +910,7 @@ package_ids:
                 "2.0.2.4": a21a3832da741b8344077a3d565550ac
                 "2.1.0": ee7336e8a1799fc479617d5774bd43c7
                 "2.1.0.1": a0eddec3d5716765c8a11086abf88624
+                "2.1.0.2": d0e9caeba57ff51e0e9d1ef5e66cd6cf
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -957,6 +966,7 @@ package_ids:
                 "2.0.2.4": 55c37ce5db55be046461e16d05f67e8d
                 "2.1.0": ad6d64e2abb7877bcac1838e84d1a91d
                 "2.1.0.1": 50123b3cd11dbc64fdb062415ff1a20f
+                "2.1.0.2": bc992ba2e26a9820ade73266a6f300d8
             renderman-maya:
                 "21.3": c691fab2d2770adc01d614e16b8d6e64
                 "21.4": ebf7f44b9e0b119b29c2768c1092c4c4
@@ -1009,6 +1019,7 @@ package_ids:
                 "2.0.2.4": 55c37ce5db55be046461e16d05f67e8d
                 "2.1.0": ad6d64e2abb7877bcac1838e84d1a91d
                 "2.1.0.1": 50123b3cd11dbc64fdb062415ff1a20f
+                "2.1.0.2": bc992ba2e26a9820ade73266a6f300d8
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -1063,6 +1074,7 @@ package_ids:
                 "2.0.2.4": 55c37ce5db55be046461e16d05f67e8d
                 "2.1.0": ad6d64e2abb7877bcac1838e84d1a91d
                 "2.1.0.1": 50123b3cd11dbc64fdb062415ff1a20f
+                "2.1.0.2": bc992ba2e26a9820ade73266a6f300d8
             miarmy:
                 "5.3.11": 01255ad4bb83bc5369d162d3af5fdec2
             renderman-maya:
@@ -1115,6 +1127,7 @@ package_ids:
                 "2.0.2.4": 262c88142f1cea62fc2556b0dd5dcc0a
                 "2.1.0": 410fe5d88fe65eb62b746b5905681c6a
                 "2.1.0.1": 379b3514603cac841e36a7b0cc06f4d9
+                "2.1.0.2": 90f7878cad296e0813028fc37e6de448
             renderman-maya:
                 "21.3": 1e7b1b9c5f011b76555d8d751a49cc32
                 "21.4": 128a1a2126250f5413db08ab19c1de25
@@ -1170,6 +1183,7 @@ package_ids:
                 "2.0.2.4": 262c88142f1cea62fc2556b0dd5dcc0a
                 "2.1.0": 410fe5d88fe65eb62b746b5905681c6a
                 "2.1.0.1": 379b3514603cac841e36a7b0cc06f4d9
+                "2.1.0.2": 90f7878cad296e0813028fc37e6de448
             renderman-maya:
                 "21.3": 1e7b1b9c5f011b76555d8d751a49cc32
                 "21.4": 128a1a2126250f5413db08ab19c1de25
@@ -1225,6 +1239,7 @@ package_ids:
                 "2.0.2.4": 262c88142f1cea62fc2556b0dd5dcc0a
                 "2.1.0": 410fe5d88fe65eb62b746b5905681c6a
                 "2.1.0.1": 379b3514603cac841e36a7b0cc06f4d9
+                "2.1.0.2": 90f7878cad296e0813028fc37e6de448
             renderman-maya:
                 "21.3": 1e7b1b9c5f011b76555d8d751a49cc32
                 "21.4": 128a1a2126250f5413db08ab19c1de25
@@ -1280,6 +1295,7 @@ package_ids:
                 "2.0.2.4": 262c88142f1cea62fc2556b0dd5dcc0a
                 "2.1.0": 410fe5d88fe65eb62b746b5905681c6a
                 "2.1.0.1": 379b3514603cac841e36a7b0cc06f4d9
+                "2.1.0.2": 90f7878cad296e0813028fc37e6de448
             renderman-maya:
                 "21.3": 1e7b1b9c5f011b76555d8d751a49cc32
                 "21.4": 128a1a2126250f5413db08ab19c1de25
@@ -1335,6 +1351,7 @@ package_ids:
                 "2.0.2.4": 262c88142f1cea62fc2556b0dd5dcc0a
                 "2.1.0": 410fe5d88fe65eb62b746b5905681c6a
                 "2.1.0.1": 379b3514603cac841e36a7b0cc06f4d9
+                "2.1.0.2": 90f7878cad296e0813028fc37e6de448
             renderman-maya:
                 "21.3": 1e7b1b9c5f011b76555d8d751a49cc32
                 "21.4": 128a1a2126250f5413db08ab19c1de25
@@ -1374,6 +1391,7 @@ package_ids:
                 "2.0.2.4": ed3839551e44709a7820cec9307a23fe
                 "2.1.0": cbe8d96aea67a3f39d17918f69312432
                 "2.1.0.1": 95a2241e0efdba008eec42deef13c24d
+                "2.1.0.2": 0c4af05117037150629d43e7a85c8389
             renderman-maya:
                 "21.6": 914263d130a20364759697ba1aef15f1
             yeti:
@@ -1395,6 +1413,7 @@ package_ids:
                 "2.0.2.4": ed3839551e44709a7820cec9307a23fe
                 "2.1.0": cbe8d96aea67a3f39d17918f69312432
                 "2.1.0.1": 95a2241e0efdba008eec42deef13c24d
+                "2.1.0.2": 0c4af05117037150629d43e7a85c8389
             renderman-maya:
                 "21.6": 914263d130a20364759697ba1aef15f1
             yeti:
@@ -1416,6 +1435,7 @@ package_ids:
                 "2.0.2.4": ed3839551e44709a7820cec9307a23fe
                 "2.1.0": cbe8d96aea67a3f39d17918f69312432
                 "2.1.0.1": 95a2241e0efdba008eec42deef13c24d
+                "2.1.0.2": 0c4af05117037150629d43e7a85c8389
             renderman-maya:
                 "21.6": 914263d130a20364759697ba1aef15f1
             yeti:

--- a/conductor/resources/resources.yml
+++ b/conductor/resources/resources.yml
@@ -1405,6 +1405,27 @@ package_ids:
                 "2.2.4": 64950eaef0d9ae5a6b72da9a8deab4bd
                 "2.2.5": 25eee62bbcca44249ec55153a79c96ae
 
+        "Autodesk Maya 2018 Update 2":
+            package: f7e93d6431686b48648a7bee94145d06
+            v-ray-maya:
+                "3.60.01": 01fcbf1131d4eb5266c67efdcbf10fae
+            arnold-maya:
+                "2.0.1": 75267da8444add2de1a9ce615834e81a
+                "2.0.2.2": 77f6759fc59c8e902d7ebcf5db1087c0
+                "2.0.2.3": 0172d14d1aa2abbd56ba4b579c4c0577
+                "2.0.2.4": ed3839551e44709a7820cec9307a23fe
+                "2.1.0": cbe8d96aea67a3f39d17918f69312432
+                "2.1.0.1": 95a2241e0efdba008eec42deef13c24d
+            renderman-maya:
+                "21.6": 914263d130a20364759697ba1aef15f1
+            yeti:
+                "2.2.0": 1fce6c44b39acdf61fc798acdcb0dd90
+                "2.2.1": 94e2209873200b6f9513aa5430c94699
+                "2.2.2": 014e4fff6adbcf264da7a1cbdb95ea18
+                "2.2.3": 68aca85ad1e694c1cee36d06cb81689b
+                "2.2.4": 64950eaef0d9ae5a6b72da9a8deab4bd
+                "2.2.5": 25eee62bbcca44249ec55153a79c96ae
+
     "nuke":
         "8.0v1":
             package: c8467d09a1cf38e7940a0f87bd01d5da

--- a/conductor/resources/resources.yml
+++ b/conductor/resources/resources.yml
@@ -1384,7 +1384,7 @@ package_ids:
                 "2.2.4": 64950eaef0d9ae5a6b72da9a8deab4bd
                 "2.2.5": 25eee62bbcca44249ec55153a79c96ae
 
-        "Autodesk Maya 2018 Update 1":
+        "Autodesk Maya 2018.1":
             package: 38015a170f892bf61e5275deac8dd421
             v-ray-maya:
                 "3.60.01": 01fcbf1131d4eb5266c67efdcbf10fae
@@ -1405,7 +1405,7 @@ package_ids:
                 "2.2.4": 64950eaef0d9ae5a6b72da9a8deab4bd
                 "2.2.5": 25eee62bbcca44249ec55153a79c96ae
 
-        "Autodesk Maya 2018 Update 2":
+        "Autodesk Maya 2018.2":
             package: f7e93d6431686b48648a7bee94145d06
             v-ray-maya:
                 "3.60.01": 01fcbf1131d4eb5266c67efdcbf10fae


### PR DESCRIPTION
It also includes PT-241 work of new naming schema for Maya 2018 Updates. #157 is being rolled into this one.