### PR TITLE
Chore/ct 595/add houdini env to installers

### DIFF
--- a/installers/osx/postinstall
+++ b/installers/osx/postinstall
@@ -7,12 +7,12 @@ echo "/Applications/Conductor.app/Contents/MacOS/bin" > /etc/paths.d/conductor
 # remove previous lines added by Conductor
 for envfile in `ls ${HOME}/Library/Preferences/houdini/*/houdini.env`
 do
-bak=${envfile}.conductor.bak
-/bin/cp -rf ${envfile} ${bak} 
-cat ${bak} | grep -v "added by Conductor" | sed '/./,$!d' > ${envfile}
-echo "" >> ${envfile}
-echo "# The following lines have been added by Conductor"  >> ${envfile}
-echo 'HOUDINI_PATH = "$HOUDINI_PATH;/Applications/Conductor.app/Contents/MacOS/conductor/conductor_client/conductor/houdini;&" # added by Conductor' >> ${envfile}
+	bak=${envfile}.conductor.bak
+	/bin/cp -rf ${envfile} ${bak} 
+	cat ${bak} | grep -v "added by Conductor" | sed '/./,$!d' > ${envfile}
+	echo "" >> ${envfile}
+	echo "# The following lines have been added by Conductor"  >> ${envfile}
+	echo 'HOUDINI_PATH = "$HOUDINI_PATH;/Applications/Conductor.app/Contents/MacOS/conductor/conductor_client/conductor/houdini;&" # added by Conductor' >> ${envfile}
 done
 
 #initialize the environment so conductor is ready to go after installation

--- a/installers/osx/postinstall
+++ b/installers/osx/postinstall
@@ -3,6 +3,18 @@
 #Put conductor in the path
 echo "/Applications/Conductor.app/Contents/MacOS/bin" > /etc/paths.d/conductor
 
+# add conductor HOUDINI_PATH in user's houdini.env files
+# remove previous lines added by Conductor
+for envfile in `ls ${HOME}/Library/Preferences/houdini/*/houdini.env`
+do
+bak=${envfile}.conductor.bak
+/bin/cp -rf ${envfile} ${bak} 
+cat ${bak} | grep -v "added by Conductor" | sed '/./,$!d' > ${envfile}
+echo "" >> ${envfile}
+echo "# The following lines have been added by Conductor"  >> ${envfile}
+echo 'HOUDINI_PATH = "$HOUDINI_PATH;/Applications/Conductor.app/Contents/MacOS/conductor/conductor_client/conductor/houdini;&" # added by Conductor' >> ${envfile}
+done
+
 #initialize the environment so conductor is ready to go after installation
 #if we don't do this the user has to log out before the environment is set up
 INSTALLER_USER=$(stat -f '%Su' $HOME)

--- a/installers/rpm/conductor.sh
+++ b/installers/rpm/conductor.sh
@@ -4,6 +4,7 @@
 export PYTHONPATH=$PYTHONPATH:/opt/conductor/python/lib/python2.7/site-packages:/opt/conductor
 export MAYA_SHELF_PATH=$MAYA_SHELF_PATH:/opt/conductor/maya_shelf
 export XBMLANGPATH=$XBMLANGPATH:/opt/conductor/conductor/resources/%B
+export HOUDINI_PATH=$HOUDINI_PATH:/opt/conductor/houdini
 export NUKE_PATH=$NUKE_PATH:/opt/conductor/nuke_menu
 export CONDUCTOR_CONFIG=$HOME/.conductor/config.yml
 export PATH=$PATH:/opt/conductor/bin

--- a/installers/windows/ConductorClient.nsi
+++ b/installers/windows/ConductorClient.nsi
@@ -81,6 +81,7 @@ ${EnvVarUpdate} $0 "PYTHONPATH" "A" "HKLM" "$INSTDIR\Conductor\python\Lib\site-p
 ${EnvVarUpdate} $0 "MAYA_SHELF_PATH" "A" "HKLM" "$INSTDIR\Conductor\maya_shelf"
 ${EnvVarUpdate} $0 "XBMLANGPATH" "A" "HKLM" "$INSTDIR\Conductor\conductor\resources"
 ${EnvVarUpdate} $0 "NUKE_PATH" "A" "HKLM" "$INSTDIR\Conductor\nuke_menu"
+${EnvVarUpdate} $0 "HOUDINI_PATH" "A" "HKLM" "$INSTDIR\Conductor\houdini"
 
 SectionEnd
 


### PR DESCRIPTION
Adding houdini_path. 

SideFX recommends adding variables in user's houdini.env, while Conductor installers tend to add variables directly to environment profiles.

I used the sidefx way for osx, and the conductor way for win & linux. 




