### PR TITLE
CT-674 removed one-camera restriction in Maya submitter

### DIFF
--- a/conductor/lib/maya_utils.py
+++ b/conductor/lib/maya_utils.py
@@ -434,11 +434,7 @@ def get_render_layers_info():
     a a render layer.  Each dictionary provides the following information:
         - render layer name
         - whether the render layer is set to renderable
-        - the camera that the render layer uses
-
-    Note that only one camera is allowed per render layer.  This is somewhat
-    of an arbitrary limitation, but implemented to reduce complexity.  This
-    restriction may need to be removed.
+        - the cameras that the render layer is set to render
 
     Note that this function is wrapped in an undo block because it actually changes
     the state of the maya session (unfortunately). There doesn't appear to be
@@ -446,7 +442,6 @@ def get_render_layers_info():
     it's state (switching the active render layer)
     '''
     render_layers = []
-    cameras = cmds.ls(type="camera", long=True)
 
     # record the original render layer so that we can set it back later. Wow this sucks
     original_render_layer = cmds.editRenderLayerGlobals(currentRenderLayer=True, q=True)
@@ -456,12 +451,18 @@ def get_render_layers_info():
             cmds.editRenderLayerGlobals(currentRenderLayer=render_layer)
         except RuntimeError:
             continue
-        renderable_cameras = [get_transform(camera) for camera in cameras if cmds.getAttr("%s.renderable" % camera)]
-        assert renderable_cameras, 'No Renderable camera found for render layer "%s"' % render_layer
-        assert len(renderable_cameras) == 1, 'More than one renderable camera found for render layer "%s". Cameras: %s' % (render_layer, renderable_cameras)
 
-        layer_info["camera_transform"] = renderable_cameras[0]
-        layer_info["camera_shortname"] = get_short_name(layer_info["camera_transform"])
+        cameras = []
+        # cycle through all renderable camereras in the maya scene
+        for camera in cmds.ls(type="camera", long=True):
+            if not cmds.getAttr("%s.renderable" % camera):
+                continue
+            camera_info = {}
+            camera_info["camera_transform"] = get_transform(camera)
+            camera_info["camera_shortname"] = get_short_name(camera_info["camera_transform"])
+            cameras.append(camera_info)
+
+        layer_info["cameras"] = cameras
         layer_info["renderable"] = cmds.getAttr("%s.renderable" % render_layer)
         render_layers.append(layer_info)
 

--- a/conductor/submitter_maya.py
+++ b/conductor/submitter_maya.py
@@ -62,11 +62,10 @@ class MayaWidget(QtWidgets.QWidget):
         self.ui_render_layers_trwgt.clear()
         assert isinstance(render_layers_info, list), "render_layers argument must be a list. Got: %s" % type(render_layers_info)
         for render_layer_info in reversed(render_layers_info):
-            tree_item = QtWidgets.QTreeWidgetItem([render_layer_info["layer_name"],
-                                                   render_layer_info["camera_shortname"]])
+            cameras_str = " ".join([c["camera_shortname"] for c in render_layer_info["cameras"]])
+            tree_item = QtWidgets.QTreeWidgetItem([render_layer_info["layer_name"], cameras_str])
 
             tree_item.setFlags(tree_item.flags() | QtCore.Qt.ItemIsUserCheckable)
-            tree_item._camera_transform = render_layer_info["camera_transform"]
             self.ui_render_layers_trwgt.addTopLevelItem(tree_item)
 
             # If the render layer is set to renderable, then check the item's checkbox on
@@ -572,7 +571,7 @@ class MayaCheckBoxTreeWidget(pyside_utils.CheckBoxTreeWidget):
         super(MayaCheckBoxTreeWidget, self).initializeUi()
         self.setIndentation(0)
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
-        self.setHeaderItem(QtWidgets.QTreeWidgetItem(["Layer", "Camera"]))
+        self.setHeaderItem(QtWidgets.QTreeWidgetItem(["Layer", "Cameras"]))
 
 
 def get_maya_window():


### PR DESCRIPTION
Render layers can now render multiple cameras
![image](https://user-images.githubusercontent.com/10409070/44512807-886a0e80-a670-11e8-9a02-2fa7b2661dc9.png)
