### PR TITLE
CT-690 Support for Renderman 22

### DIFF
--- a/conductor/resources/resources.yml
+++ b/conductor/resources/resources.yml
@@ -1451,6 +1451,7 @@ package_ids:
                 "21.5": cb14ddba549aefa42f8f047e6682f470
                 "21.6": 5c058e15fd8be1105e18db9687444898
                 "21.7": fe2dcf01b8ed1dc24005b399d47a3004
+                "1.0": 16d3a54a07910d404295ad14561a9dab
             yeti:
                 "2.1.0": 56ee9e6997ccb7152793b341f068bb38
                 "2.1.1": daa939be7dc3308540fa058bdd8683bc
@@ -1520,6 +1521,7 @@ package_ids:
                 "21.5": cb14ddba549aefa42f8f047e6682f470
                 "21.6": 5c058e15fd8be1105e18db9687444898
                 "21.7": fe2dcf01b8ed1dc24005b399d47a3004
+                "1.0": 16d3a54a07910d404295ad14561a9dab
             yeti:
                 "2.1.0": 56ee9e6997ccb7152793b341f068bb38
                 "2.1.1": daa939be7dc3308540fa058bdd8683bc
@@ -1589,6 +1591,7 @@ package_ids:
                 "21.5": cb14ddba549aefa42f8f047e6682f470
                 "21.6": 5c058e15fd8be1105e18db9687444898
                 "21.7": fe2dcf01b8ed1dc24005b399d47a3004
+                "1.0": 16d3a54a07910d404295ad14561a9dab
             yeti:
                 "2.1.0": 56ee9e6997ccb7152793b341f068bb38
                 "2.1.1": daa939be7dc3308540fa058bdd8683bc
@@ -1713,6 +1716,7 @@ package_ids:
             renderman-maya:
                 "21.6": 914263d130a20364759697ba1aef15f1
                 "21.7": 0a76e5128751083ee34eb4efd450dec2
+                "1.0": 4f12cd8b807ceb35bccee7a833f6ab38
             yeti:
                 "2.2.0": 1fce6c44b39acdf61fc798acdcb0dd90
                 "2.2.1": 94e2209873200b6f9513aa5430c94699


### PR DESCRIPTION
Note that Renderman 22 is only officially supported (by pixar) for a
handful of maya versions (hence the absence of some auto-matching
versions).
Supported maya versions:
 - 2017 Update 3+
 - 2018 Update 2

see https://rmanwiki.pixar.com/display/REN22/Installation+and+Licensing

![image](https://user-images.githubusercontent.com/10409070/45239418-01d14600-b29a-11e8-8c6e-7fcb51a523e2.png)
