### PR TITLE
adds confirmation dialog for large jobs

### DIFF
--- a/conductor/submitter.py
+++ b/conductor/submitter.py
@@ -1094,8 +1094,9 @@ class ConductorSubmitter(QtWidgets.QMainWindow):
             return True
         chunk_size = self.getChunkSize()
 
+        # To count the tasks, we have to make a generator and sum 1 for every yield
         task_counter =  TaskFramesGenerator( frames, chunk_size=chunk_size, uniform_chunk_step=True)
-        task_count = sum((1 for _ in task_counter))
+        task_count = sum(1 for _ in task_counter)
 
 
         if task_count < TASK_CONFIRMATION_THRESHOLD:

--- a/conductor/submitter.py
+++ b/conductor/submitter.py
@@ -1080,13 +1080,18 @@ class ConductorSubmitter(QtWidgets.QMainWindow):
         """
         Make sure the user is aware they are about submit a large job.
 
-        If a large job is submiited by mistake, it can be difficult to 
-        kill it. Or worse, if the customer fails to check the dashboard 
-        they could run up thousands of dollars rendering black.
+        A large job has more tasks than a threshold. 
+        We first test the number of frames, because calculating 
+        the number of tasks is slow. If frames length is below the
+        threshold, then there can't possibly be too many tasks. If 
+        there are too many tasks, then show the confirmation dialog.
+
         """
         logger.debug("Check job size")
         frames_str = self.getFrameRangeString()
         frames = seqLister.expandSeq(frames_str.split(","), None)
+        if len(frames) < TASK_CONFIRMATION_THRESHOLD:
+            return True
         chunk_size = self.getChunkSize()
         task_count = len(TaskFramesGenerator(
             frames, chunk_size=chunk_size, uniform_chunk_step=True))

--- a/conductor/submitter.py
+++ b/conductor/submitter.py
@@ -1093,8 +1093,11 @@ class ConductorSubmitter(QtWidgets.QMainWindow):
         if len(frames) < TASK_CONFIRMATION_THRESHOLD:
             return True
         chunk_size = self.getChunkSize()
-        task_count = len(TaskFramesGenerator(
-            frames, chunk_size=chunk_size, uniform_chunk_step=True))
+
+        task_counter =  TaskFramesGenerator( frames, chunk_size=chunk_size, uniform_chunk_step=True)
+        task_count = sum((1 for _ in task_counter))
+
+
         if task_count < TASK_CONFIRMATION_THRESHOLD:
             return True
 
@@ -1987,16 +1990,6 @@ class TaskFramesGenerator(object):
                 break
 
         return task_frames
-
-
-    def  __len__(self):
-        '''
-        Support len().
-
-        Count the number of generated tasks by iterating.
-        '''
-        return sum([1 for _a, _b, _c, _d in self])
-
 
     @classmethod
     def derive_steps(cls, frames):


### PR DESCRIPTION
The large job confirmation dialog appears when the **task** count exceeds a threshold, because I assume the difficulty in killing jobs is based on the number of tasks, not frames.