### PR TITLE
adds regex for vray tile ref

### DIFF
--- a/conductor/lib/file_utils.py
+++ b/conductor/lib/file_utils.py
@@ -13,6 +13,7 @@ RX_PERCENT = r"%0\d+d"  # image.%04d.exr
 RX_UDIM_MARI = r"<UDIM>"  # image.<UDIM>.exr
 RX_UDIM_MUDBOX = r"<UVTILE>"  # image.<UVTILE>.exr
 RX_UDIM_VRAY = r"\$\d*U.*\$\d*V"  # image.u$2U_v$2V.exr or image.u$Uv$V.exr, etc
+RX_TILE_REF_VRAY  = r"<[a-zA-Z]\d+>" #  image.<A30>.0001.exr
 RX_HOUDINI = r"\$F\d*"  # image.$F.exr
 RX_ASTERISK = r"\*+"  # image.*.exr
 RX_UDIM_ZBRUSH = r"u<U>_v<V>"  # image.u<U>_v<V>.exr
@@ -33,6 +34,7 @@ PATH_EXPRESSIONS = (
     RX_UDIM_MARI,
     RX_UDIM_MUDBOX,
     RX_UDIM_VRAY,
+    RX_TILE_REF_VRAY,
     RX_HOUDINI,
     RX_FRAME_SEQ,
     RX_ASTERISK,


### PR DESCRIPTION
https://conductorio.zendesk.com/agent/tickets/1613
> eg: Tile_<TileRef>.jpg
> TileRef could be A01, A02, B01 and so on.