### PR TITLE
Ct 959 colored logging

### DIFF
--- a/conductor/__init__.py
+++ b/conductor/__init__.py
@@ -1,24 +1,56 @@
 import logging
+import sys
+
 from conductor.lib import common, loggeria
 
 # The version string is updated by the build system.
 # Do not modify the following line.
 # __version__="0.0.0"
 
-# Adding basicConfig because it supresses logging handler
-# failures in Clarisse. It doesn't seem to affect the
-# conductor logger behaviour in other places.
-logging.basicConfig()
-
 # Read the config yaml file upon module import
 try:
     CONFIG = common.Config().config
 except ValueError:
-    # wizard.run()
     CONFIG = common.Config().config
 
-# IF there is log level specified in config (which by default there should
+
+class LogLevelFilter(logging.Filter):
+    """Filter log messages based on level.
+
+    By default, the logger sends everything to stderr. This is a problem
+    in Clarisse at least, because stderr prints RED in the log panel and
+    it pops up a floating window to display what it thinks is an error.
+    Customers get worried. To alleviate this we make 2 handlers, one for
+    stdout and one for stderr, and we route the appropriate log records
+    to each. This filter only allows warning, info, and debug records
+    and will be used by a handler to log to stdout. The stderr handler
+    simply has it's level set for error and critical records only.
+    """
+
+    def __init__(self, name=""):
+        super(LogLevelFilter, self).__init__(name)
+
+    def filter(self, record):
+        return int(record.levelno < logging.ERROR)
+
+
+logger = logging.getLogger(__name__)
+
+# Handle debug, info, warning records only.
+logging_handler_out = logging.StreamHandler(sys.stdout)
+logging_handler_out.setLevel(logging.DEBUG)
+logging_handler_out.addFilter(LogLevelFilter())
+logger.addHandler(logging_handler_out)
+
+# Handle error and critical records only.
+logging_handler_err = logging.StreamHandler(sys.stderr)
+logging_handler_err.setLevel(logging.ERROR)
+logger.addHandler(logging_handler_err)
+
+
+# If there is log level specified in config (which by default there should
 # be), then set it for conductor's logger
 log_level = CONFIG.get("log_level")
 if log_level:
     loggeria.set_conductor_log_level(log_level)
+ 

--- a/conductor/__init__.py
+++ b/conductor/__init__.py
@@ -4,15 +4,15 @@ from conductor.lib import common, loggeria
 # Do not modify the following line.
 # __version__="0.0.0"
 
-# Read the config yaml file upon module import
+# Read the config yaml file upon module import.
 try:
     CONFIG = common.Config().config
 except ValueError:
     CONFIG = common.Config().config
 
 
-# Must setup logging before setting the level, otherwise we get a
-# complaint about no handlers for logger conductor.
+# Must setup logging before setting the level, otherwise we get an
+# annoying complaint about no handlers for logger conductor.
 loggeria.setup_conductor_logging()
 log_level = CONFIG.get("log_level")
 if log_level:

--- a/conductor/__init__.py
+++ b/conductor/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 from conductor.lib import common, loggeria
 
-# The version string is updated by the build system.
+# The version string is updated by the build system. (No it isn't)
 # Do not modify the following line.
 # __version__="0.0.0"
 
@@ -14,43 +14,18 @@ except ValueError:
     CONFIG = common.Config().config
 
 
-class LogLevelFilter(logging.Filter):
-    """Filter log messages based on level.
-
-    By default, the logger sends everything to stderr. This is a problem
-    in Clarisse at least, because stderr prints RED in the log panel and
-    it pops up a floating window to display what it thinks is an error.
-    Customers get worried. To alleviate this we make 2 handlers, one for
-    stdout and one for stderr, and we route the appropriate log records
-    to each. This filter only allows warning, info, and debug records
-    and will be used by a handler to log to stdout. The stderr handler
-    simply has it's level set for error and critical records only.
-    """
-
-    def __init__(self, name=""):
-        super(LogLevelFilter, self).__init__(name)
-
-    def filter(self, record):
-        return int(record.levelno < logging.ERROR)
-
-
-logger = logging.getLogger(__name__)
-
-# Handle debug, info, warning records only.
-logging_handler_out = logging.StreamHandler(sys.stdout)
-logging_handler_out.setLevel(logging.DEBUG)
-logging_handler_out.addFilter(LogLevelFilter())
-logger.addHandler(logging_handler_out)
-
-# Handle error and critical records only.
-logging_handler_err = logging.StreamHandler(sys.stderr)
-logging_handler_err.setLevel(logging.ERROR)
-logger.addHandler(logging_handler_err)
-
-
-# If there is log level specified in config (which by default there should
-# be), then set it for conductor's logger
+# Must setup logging before setting the level, otherwise we get a 
+# complaint about no handlers for logger conductor.
+loggeria.setup_conductor_logging()
 log_level = CONFIG.get("log_level")
 if log_level:
     loggeria.set_conductor_log_level(log_level)
  
+
+logger = loggeria.get_conductor_logger()
+
+logger.debug('DEBUG')
+logger.info('INFO')
+logger.warning('WARNING')
+logger.error('ERROR')
+logger.critical('CRITICAL')

--- a/conductor/__init__.py
+++ b/conductor/__init__.py
@@ -1,6 +1,3 @@
-import logging
-import sys
-
 from conductor.lib import common, loggeria
 
 # The version string is updated by the build system. (No it isn't)
@@ -14,18 +11,9 @@ except ValueError:
     CONFIG = common.Config().config
 
 
-# Must setup logging before setting the level, otherwise we get a 
+# Must setup logging before setting the level, otherwise we get a
 # complaint about no handlers for logger conductor.
 loggeria.setup_conductor_logging()
 log_level = CONFIG.get("log_level")
 if log_level:
     loggeria.set_conductor_log_level(log_level)
- 
-
-logger = loggeria.get_conductor_logger()
-
-logger.debug('DEBUG')
-logger.info('INFO')
-logger.warning('WARNING')
-logger.error('ERROR')
-logger.critical('CRITICAL')

--- a/conductor/lib/loggeria.py
+++ b/conductor/lib/loggeria.py
@@ -94,20 +94,20 @@ def setup_conductor_logging(logger_level=DEFAULT_LEVEL_LOGGER,
     """
     # Get the top/parent conductor logger
     logger = get_conductor_logger()
-    
+
     if logger_level:
         assert logger_level in LEVEL_MAP.values(), "Not a valid log level: %s" % logger_level
         # Set the main log level. Note that if this is super restrive, you
         # won't see handler messages, regardless of the handlers' log level
         logger.setLevel(logger_level)
 
-    # Handle debug, info, warning records only.
+    # Handle debug, info, warning records only. STDOUT
     console_handler_out = logging.StreamHandler(sys.stdout)
     console_handler_out.setLevel(logging.DEBUG)
     console_handler_out.addFilter(LogLevelFilter())
     logger.addHandler(console_handler_out)
 
-    # Handle error and critical records only.
+    # Handle error and critical records only. STDERR
     console_handler_err = logging.StreamHandler(sys.stderr)
     console_handler_err.setLevel(logging.ERROR)
     logger.addHandler(console_handler_err)
@@ -261,22 +261,18 @@ class MPFileHandler(logging.Handler):
 
 
 class TableStr(object):
-    """A class to help log/print tables of data.
+    '''
+    A class to help log/print tables of data
+    
+    ############## DOWNLOAD HISTORY #################
+    COMPLETED AT         DOWNLOAD ID       JOB    TASK       SIZE  ACTION  DURATION  THREAD     FILEPATH
+    2016-01-16 01:12:46  5228833175240704  00208  010    137.51MB  DL      0:00:57   Thread-12  /tmp/conductor_daemon_dl/04/cental/cental.010.exr
+    2016-01-16 01:12:42  6032237141164032  00208  004    145.48MB  DL      0:02:24   Thread-2   /tmp/conductor_daemon_dl/04/cental/cental.004.exr
+    2016-01-16 01:12:40  5273802288136192  00208  012    140.86MB  DL      0:02:02   Thread-16  /tmp/conductor_daemon_dl/04/cental/cental.012.exr
+    '''
 
-    ############## DOWNLOAD HISTORY ################# COMPLETED AT
-    DOWNLOAD ID       JOB    TASK       SIZE  ACTION  DURATION  THREAD
-    FILEPATH 2016-01-16 01:12:46  5228833175240704  00208  010
-    137.51MB  DL      0:00:57   Thread-12
-    /tmp/conductor_daemon_dl/04/cental/cental.010.exr 2016-01-16
-    01:12:42  6032237141164032  00208  004    145.48MB  DL      0:02:24
-    Thread-2   /tmp/conductor_daemon_dl/04/cental/cental.004.exr
-    2016-01-16 01:12:40  5273802288136192  00208  012    140.86MB  DL
-    0:02:02   Thread-16
-    /tmp/conductor_daemon_dl/04/cental/cental.012.exr
-    """
-
-    # A dict which contains callable functions that can be used to condition
-    # each column entry of the table
+    # A dict which contains callable functions that can be used 
+    # to condition each column entry of the table
     header_modifiers = {}
 
     cell_modifiers = {}
@@ -362,7 +358,8 @@ class TableStr(object):
         return column_strs
 
     def modify_header(self, column_name):
-        """Modify and return the given column name.
+        """
+        Modify and return the given column name.
 
         This provides an opportunity to adjust what the header should
         consist of.

--- a/conductor/lib/loggeria.py
+++ b/conductor/lib/loggeria.py
@@ -1,13 +1,11 @@
-import os
 import logging
 import logging.handlers
-from logging.handlers import TimedRotatingFileHandler
 import multiprocessing
+import os
 import sys
 import threading
 import traceback
-
-
+from logging.handlers import TimedRotatingFileHandler
 
 LEVEL_CRITICAL = "CRITICAL"
 LEVEL_ERROR = "ERROR"
@@ -16,7 +14,13 @@ LEVEL_INFO = "INFO"
 LEVEL_DEBUG = "DEBUG"
 LEVEL_NOTSET = "NOTSET"
 
-LEVELS = [LEVEL_CRITICAL, LEVEL_ERROR, LEVEL_WARNING, LEVEL_INFO, LEVEL_DEBUG, LEVEL_NOTSET]
+LEVELS = [
+    LEVEL_CRITICAL,
+    LEVEL_ERROR,
+    LEVEL_WARNING,
+    LEVEL_INFO,
+    LEVEL_DEBUG,
+    LEVEL_NOTSET]
 
 
 LEVEL_MAP = {LEVEL_CRITICAL: logging.CRITICAL,
@@ -27,13 +31,37 @@ LEVEL_MAP = {LEVEL_CRITICAL: logging.CRITICAL,
              LEVEL_NOTSET: logging.NOTSET}
 
 
-FORMATTER_LIGHT = logging.Formatter('%(asctime)s %(name)s: %(message)s', "%Y-%m-%d %H:%M:%S")
-FORMATTER_VERBOSE = logging.Formatter('%(asctime)s %(name)s%(levelname)9s:  %(message)s')
+FORMATTER_LIGHT = logging.Formatter(
+    '%(asctime)s %(name)s: %(message)s',
+    "%Y-%m-%d %H:%M:%S")
+FORMATTER_VERBOSE = logging.Formatter(
+    '%(asctime)s %(name)s%(levelname)9s:  %(message)s')
 DEFAULT_LEVEL_CONSOLE = LEVEL_MAP[LEVEL_INFO]
 DEFAULT_LEVEL_FILE = LEVEL_MAP[LEVEL_DEBUG]
 DEFAULT_LEVEL_LOGGER = LEVEL_MAP[LEVEL_INFO]
 
 CONDUCTOR_LOGGER_NAME = "conductor"
+
+
+class LogLevelFilter(logging.Filter):
+    """Filter log messages based on level.
+
+    By default, the logger sends everything to stderr. This is a problem
+    in Clarisse at least, because stderr prints RED in the log panel and
+    pops up a floating window to display what it thinks is an error.
+    Customers get worried. To alleviate this we make 2 handlers, one for
+    stdout and one for stderr, and we route the appropriate log records
+    to each. This filter only allows warning, info, and debug records
+    and will be used by the handler that logs to stdout. The stderr
+    handler doesn't need a filter as it simply has it's level set for
+    error and critical records only.
+    """
+
+    def __init__(self, name=""):
+        super(LogLevelFilter, self).__init__(name)
+
+    def filter(self, record):
+        return int(record.levelno < logging.ERROR)
 
 
 def setup_conductor_logging(logger_level=DEFAULT_LEVEL_LOGGER,
@@ -43,8 +71,7 @@ def setup_conductor_logging(logger_level=DEFAULT_LEVEL_LOGGER,
                             file_level=None,
                             file_formatter=FORMATTER_VERBOSE,
                             multiproc=False):
-    '''
-    The is convenience function to help set up logging.
+    """The is convenience function to help set up logging.
 
     THIS SHOULD ONLY BE CALLED ONCE within an execution environment.
 
@@ -52,9 +79,8 @@ def setup_conductor_logging(logger_level=DEFAULT_LEVEL_LOGGER,
 
     1. Creates/retrieves the logger object for the "conductor" package
     2. Sets that logger's  log level to the given logger_level (optional)
-    3. Creates a console handler and attaches it to the logger object.
-    3a. Optionally sets that console handler's log level to the given console_level
-    3b. Optionally sets that console handler's formatter to the the given console_formatter
+    3. Creates two console handlers (stderr and stdout) and attaches them to the logger object.
+    3a. Optionally sets that console handler's formatter to the the given console_formatter
     4.  Optionally creates a file handler (if a log filepath is given)
     4a. Optionally sets that file handler's log level to the given file_level
     4b. Optionally sets that file handler's formatter to the the given file_formatter
@@ -65,63 +91,75 @@ def setup_conductor_logging(logger_level=DEFAULT_LEVEL_LOGGER,
 
     multiproc: bool. If True, a custom file handler will be used that handles multiprocess
                logging correctly. This file handler creates an additional Process.
-
-    '''
+    """
     # Get the top/parent conductor logger
     logger = get_conductor_logger()
+    
     if logger_level:
         assert logger_level in LEVEL_MAP.values(), "Not a valid log level: %s" % logger_level
-        # Set the main log level. Note that if this is super restrive, you won't see handler messages, regardless of the handlers' log level
+        # Set the main log level. Note that if this is super restrive, you
+        # won't see handler messages, regardless of the handlers' log level
         logger.setLevel(logger_level)
 
-        # Console handler for outputting log to screen
-    console_handler = logging.StreamHandler()
-    logger.addHandler(console_handler)
+    # Handle debug, info, warning records only.
+    console_handler_out = logging.StreamHandler(sys.stdout)
+    console_handler_out.setLevel(logging.DEBUG)
+    console_handler_out.addFilter(LogLevelFilter())
+    logger.addHandler(console_handler_out)
+
+    # Handle error and critical records only.
+    console_handler_err = logging.StreamHandler(sys.stderr)
+    console_handler_err.setLevel(logging.ERROR)
+    logger.addHandler(console_handler_err)
 
     # create formatter and apply it to the handlers
     if console_formatter:
-        console_handler.setFormatter(console_formatter)
+        console_handler_out.setFormatter(console_formatter)
+        console_handler_err.setFormatter(console_formatter)
 
-    # Set the console log level (note that the main logger object will make this irrelevant if the main logger's level is too restricitve)
-    if console_level:
-        assert console_level in LEVEL_MAP.values(), "Not a valid log level: %s" % console_level
-        console_handler.setLevel(console_level)
 
     # Create a file handler if a filepath was given
     if log_filepath:
         if file_level:
             assert file_level in LEVEL_MAP.values(), "Not a valid log level: %s" % file_level
-        # Rotating file handler. Rotates every day (24 hours). Stores 7 days at a time.
-        file_handler = create_file_handler(log_filepath, level=file_level, formatter=file_formatter, multiproc=multiproc)
+        # Rotating file handler. Rotates every day (24 hours). Stores 7 days at
+        # a time.
+        file_handler = create_file_handler(
+            log_filepath,
+            level=file_level,
+            formatter=file_formatter,
+            multiproc=multiproc)
         logger.addHandler(file_handler)
 
 
-
 def create_file_handler(filepath, level=None, formatter=None, multiproc=False):
-    '''
-    Create a file handler object for the given filepath.
-    This is a ROTATING file handler, which rotates every day (24 hours) and
-    stores up to 7 days of logs at a time (equaling up to as many as 7 log files
-    at a given time.
-    '''
+    """Create a file handler object for the given filepath.
+
+    This is a ROTATING file handler, which rotates every day (24 hours)
+    and stores up to 7 days of logs at a time (equaling up to as many as
+    7 log files at a given time.
+    """
     when = 'h'  # rotate unit is "h" (hours)
     interval = 24  # rotate every  24 units (24 hours)
     backupCount = 7  # Retain up to 7 log files (7 days of log files)
-
 
     log_dirpath = os.path.dirname(filepath)
     if not os.path.exists(log_dirpath):
         os.makedirs(log_dirpath)
 
     if multiproc:
-        # Use custom rotating file handler that handles multiprocessing properly
-        handler = MPFileHandler(filepath, when=when, interval=interval, backupCount=backupCount)
+        # Use custom rotating file handler that handles multiprocessing
+        # properly
+        handler = MPFileHandler(
+            filepath,
+            when=when,
+            interval=interval,
+            backupCount=backupCount)
     else:
-        # Rotating file handler. Rotates every day (24 hours). Stores 7 days at a time.
-        handler = logging.handlers.TimedRotatingFileHandler(filepath,
-                                                            when=when,
-                                                            interval=interval,
-                                                            backupCount=backupCount)
+        # Rotating file handler. Rotates every day (24 hours). Stores 7 days at
+        # a time.
+        handler = logging.handlers.TimedRotatingFileHandler(
+            filepath, when=when, interval=interval, backupCount=backupCount)
     if formatter:
         handler.setFormatter(formatter)
 
@@ -132,9 +170,7 @@ def create_file_handler(filepath, level=None, formatter=None, multiproc=False):
 
 
 def set_conductor_log_level(log_level):
-    '''
-    Set the "conductor" package's logger to the given log level
-    '''
+    """Set the "conductor" package's logger to the given log level."""
     assert log_level in LEVEL_MAP.keys(), "Invalid log_level: %s" % log_level
     logger = get_conductor_logger()
     logger.setLevel(log_level)
@@ -142,26 +178,26 @@ def set_conductor_log_level(log_level):
 
 
 def get_conductor_logger():
-    '''
-    Return the "conductor" package's logger object
-    '''
+    """Return the "conductor" package's logger object."""
     return logging.getLogger(CONDUCTOR_LOGGER_NAME)
 
 
-
-
 class MPFileHandler(logging.Handler):
-    '''
-    Multiprocess-safe Rotating File Handler
+    """Multiprocess-safe Rotating File Handler.
 
     Copied from: http://stackoverflow.com/questions/641420/how-should-i-log-while-using-multiprocessing-in-python
-    '''
+    """
 
-
-    def __init__(self, filename, when='h', interval=1, backupCount=0, encoding=None, delay=0, utc=0):
-        '''
-        See TimedRotatingFileHandler for arg docs
-        '''
+    def __init__(
+            self,
+            filename,
+            when='h',
+            interval=1,
+            backupCount=0,
+            encoding=None,
+            delay=0,
+            utc=0):
+        """See TimedRotatingFileHandler for arg docs."""
         logging.Handler.__init__(self)
         self._handler = TimedRotatingFileHandler(filename,
                                                  when=when,
@@ -170,7 +206,6 @@ class MPFileHandler(logging.Handler):
                                                  encoding=encoding,
                                                  delay=delay,
                                                  utc=utc)
-
 
         self.queue = multiprocessing.Queue()
 
@@ -191,7 +226,7 @@ class MPFileHandler(logging.Handler):
                 raise
             except EOFError:
                 break
-            except:
+            except BaseException:
                 traceback.print_exc(file=sys.stderr)
 
     def send(self, s):
@@ -217,7 +252,7 @@ class MPFileHandler(logging.Handler):
             self.send(s)
         except (KeyboardInterrupt, SystemExit):
             raise
-        except:
+        except BaseException:
             self.handleError(record)
 
     def close(self):
@@ -225,22 +260,23 @@ class MPFileHandler(logging.Handler):
         logging.Handler.close(self)
 
 
-
-
 class TableStr(object):
-    '''
-    
-    A class to help log/print tables of data
-    
-    ############## DOWNLOAD HISTORY #################
-    COMPLETED AT         DOWNLOAD ID       JOB    TASK       SIZE  ACTION  DURATION  THREAD     FILEPATH
-    2016-01-16 01:12:46  5228833175240704  00208  010    137.51MB  DL      0:00:57   Thread-12  /tmp/conductor_daemon_dl/04/cental/cental.010.exr
-    2016-01-16 01:12:42  6032237141164032  00208  004    145.48MB  DL      0:02:24   Thread-2   /tmp/conductor_daemon_dl/04/cental/cental.004.exr
-    2016-01-16 01:12:40  5273802288136192  00208  012    140.86MB  DL      0:02:02   Thread-16  /tmp/conductor_daemon_dl/04/cental/cental.012.exr
+    """A class to help log/print tables of data.
 
-    '''
+    ############## DOWNLOAD HISTORY ################# COMPLETED AT
+    DOWNLOAD ID       JOB    TASK       SIZE  ACTION  DURATION  THREAD
+    FILEPATH 2016-01-16 01:12:46  5228833175240704  00208  010
+    137.51MB  DL      0:00:57   Thread-12
+    /tmp/conductor_daemon_dl/04/cental/cental.010.exr 2016-01-16
+    01:12:42  6032237141164032  00208  004    145.48MB  DL      0:02:24
+    Thread-2   /tmp/conductor_daemon_dl/04/cental/cental.004.exr
+    2016-01-16 01:12:40  5273802288136192  00208  012    140.86MB  DL
+    0:02:02   Thread-16
+    /tmp/conductor_daemon_dl/04/cental/cental.012.exr
+    """
 
-    # A dict which contains callable functions that can be used to condition each column entry of the table
+    # A dict which contains callable functions that can be used to condition
+    # each column entry of the table
     header_modifiers = {}
 
     cell_modifiers = {}
@@ -250,20 +286,25 @@ class TableStr(object):
 
     row_spacer = "\n"
 
-
-    def __init__(self, data, column_names, title="", footer="", upper_headers=True):
+    def __init__(
+            self,
+            data,
+            column_names,
+            title="",
+            footer="",
+            upper_headers=True):
         '''
         args:
             data: list of dicts. Each dict represents a row, where the key is the
                   column name, and the value is the...value
-            
+
             column_names: list of str. The columns of data to show (and the order
                           in which they are shown)
-            
+
             title: str. if provided, will be printed above the table
-            
+
             footer: str. if provided, will be printed below the table
-        
+
             upper_headers: bool. If True, will automatically uppercase the column
                            header names
         '''
@@ -273,25 +314,24 @@ class TableStr(object):
         self.footer = footer
         self.uppper_headers = upper_headers
 
-
     def make_table_str(self):
-        '''
-        Create and return a final table string that is suitable to print/log.
-        
+        """Create and return a final table string that is suitable to
+        print/log.
+
         This is achieved by creating a list of items for each column in the table.
         Once all column lists have been created, they are then joined via a constant
         column space character(s) - self.column_spacer. The rows that are created
         from the columns are then prefixed with given title (self.title) and suffixed
         with the given footer (self.footer)
-
-          
-        '''
+        """
         column_strs = {}
         for column_name in self.column_names:
-            column_strs[column_name] = self.make_column_strs(column_name, self.data)
+            column_strs[column_name] = self.make_column_strs(
+                column_name, self.data)
 
         rows = []
-        for row_idx in range(len(self.data) + 1):  # add 1 to account for header row
+        for row_idx in range(
+                len(self.data) + 1):  # add 1 to account for header row
             row_data = []
             for column_name in self.column_names:
                 row_data.append(column_strs[column_name][row_idx])
@@ -301,13 +341,9 @@ class TableStr(object):
         rows.append(self.get_footer())
         return self.row_spacer.join(rows)
 
-
     def make_column_strs(self, column_name, data):
-        '''
-        
-        Return a two dimensial list (list of lists), where the inner lists
-        repersent a column of data.
-        '''
+        """Return a two dimensial list (list of lists), where the inner lists
+        repersent a column of data."""
         column_header = self.modify_header(column_name)
 
         column_cells = []
@@ -325,28 +361,27 @@ class TableStr(object):
 
         return column_strs
 
-
     def modify_header(self, column_name):
-        '''
-        Modify and return the given column name.  This provides an opportunity
-        to adjust what the header should consist of.
-        '''
+        """Modify and return the given column name.
+
+        This provides an opportunity to adjust what the header should
+        consist of.
+        """
         header_modifier = self.header_modifiers.get(column_name)
         if header_modifier:
             column_name = header_modifier(column_name)
         return column_name.upper() if self.uppper_headers else column_name
 
-
     def modify_cell(self, column_name, cell_data):
-        '''
-        Modify and return the given cell data of the given column name.
-        This provides an opportunity to adjust what the header should consist of.
-        '''
+        """Modify and return the given cell data of the given column name.
+
+        This provides an opportunity to adjust what the header should
+        consist of.
+        """
         cell_modifier = self.cell_modifiers.get(column_name)
         if cell_modifier:
             cell_data = cell_modifier(cell_data)
-        return  cell_data
-
+        return cell_data
 
     def get_title(self):
         return self.title
@@ -389,5 +424,3 @@ class TableStr(object):
 #
 #     logger.removeHandler(old_file_handler)
 #     logger.addHandler(new_file_handler)
-
-


### PR DESCRIPTION
Deceptive branch name. 
It's really about making info messages look and behave like info and not errors. Otherwise, in Clarisse, everything is red and all messages throw up an error modal that you have to click on to be rid of.

So this PR:
1. replaces the single console handler with 2 handlers, one of which uses a filter. In this way, different level messages are routed to different handlers.

2. Fixes the complaint about `no handlers for logger conductor` by setting up logging _before_ setting the log level in __init__.py. In fact, that had previously been fixed, but this is less of a hack. I'm wondering if both  `setup_conductor_logging`and `set_conductor_log_level` should be moved out of __init__.py anyway? Thoughts?

3. Pep8 and import sort.

Tested in Clarisse and Maya. Logging still works. 
Tried different levels in config.yml and get the expected effect.

If there are reservations about this, no problem. I can merge to clarisse-beta branch and play with it there for a while - make sure it's solid.