### PR TITLE
Using Qt.QtCompat.loadUi()

### DIFF
--- a/conductor/lib/pyside_utils.py
+++ b/conductor/lib/pyside_utils.py
@@ -1,59 +1,8 @@
 import logging
-import Qt
 from functools import wraps
 from Qt import QtGui, QtCore, QtWidgets
 
-try:
-    from Qt import QtUiTools
-except ImportError as e:
-    if Qt.__binding__ in ('PySide'):
-        from PySide import QtUiTools
-    else:
-        from PySide2 import QtUiTools
-
 logger = logging.getLogger(__name__)
-
-
-class UiLoader(QtUiTools.QUiLoader):
-    '''
-    #TODO: Re-write docs/comments for this class
-
-    Load a Qt Designer .ui file and returns an instance of the user interface.
-
-    This was taken almost 100% verbatim from a stack overflow example.
-    '''
-
-    def __init__(self, baseinstance):
-        super(UiLoader, self).__init__(baseinstance)
-        self.baseinstance = baseinstance
-
-    def createWidget(self, class_name, parent=None, name=''):
-        if parent is None and self.baseinstance:
-            # supposed to create the top-level widget, return the base instance
-            # instead
-            return self.baseinstance
-        else:
-            # create a new widget for child widgets
-            widget = QtUiTools.QUiLoader.createWidget(self, class_name, parent, name)
-            if self.baseinstance:
-                # set an attribute for the new child widget on the base
-                # instance, just like uic.loadUi does.
-                setattr(self.baseinstance, name, widget)
-            return widget
-
-    @classmethod
-    def loadUi(cls, uifile, baseinstance=None):
-        '''
-        Load a Qt Designer .ui file and returns an instance of the user interface.
-
-        uifile: the file name or file-like object containing the .ui file.
-        baseinstance: the optional instance of the Qt base class. If specified then the user interface is created in it. Otherwise a new instance of the base class is automatically created.
-        Return type: the QWidget sub-class that implements the user interface.
-        '''
-        loader = cls(baseinstance)
-        widget = loader.load(uifile)
-        QtCore.QMetaObject.connectSlotsByName(widget)
-        return widget
 
 
 def wait_cursor(func):

--- a/conductor/submitter.py
+++ b/conductor/submitter.py
@@ -7,7 +7,7 @@ import logging
 import os
 import operator
 from pprint import pformat
-from Qt import QtGui, QtCore, QtWidgets
+from Qt import QtGui, QtCore, QtCompat, QtWidgets
 import sys
 import traceback
 from conductor.lib.lsseq import seqLister
@@ -92,7 +92,7 @@ class ConductorSubmitter(QtWidgets.QMainWindow):
         3. Load any user settings to restore widget values from user preferences
         '''
         super(ConductorSubmitter, self).__init__(parent=parent)
-        pyside_utils.UiLoader.loadUi(self._ui_filepath, self)
+        QtCompat.loadUi(self._ui_filepath, baseinstance=self)
 
         # Create widgets
         self.createUI()

--- a/conductor/submitter_maya.py
+++ b/conductor/submitter_maya.py
@@ -10,7 +10,7 @@ import sys
 import traceback
 import uuid
 import Qt
-from Qt import QtGui, QtCore, QtWidgets
+from Qt import QtGui, QtCompat, QtCore, QtWidgets
 
 # For backwards compatibility
 if Qt.__binding__ in ('PySide'):
@@ -40,7 +40,7 @@ class MayaWidget(QtWidgets.QWidget):
 
     def __init__(self, parent=None):
         super(MayaWidget, self).__init__(parent=parent)
-        pyside_utils.UiLoader.loadUi(self._ui_filepath, self)
+        QtCompat.loadUi(self._ui_filepath, baseinstance=self)
         self.createUI()
 
     def createUI(self):
@@ -112,7 +112,7 @@ class MayaAdvancedWidget(QtWidgets.QWidget):
 
     def __init__(self, parent=None):
         super(MayaAdvancedWidget, self).__init__(parent=parent)
-        pyside_utils.UiLoader.loadUi(self._ui_filepath, self)
+        QtCompat.loadUi(self._ui_filepath, baseinstance=self)
 
     def setWorkspaceDir(self, text):
         '''

--- a/conductor/submitter_nuke.py
+++ b/conductor/submitter_nuke.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-from Qt import QtGui, QtCore, QtWidgets
+from Qt import QtGui, QtCompat, QtCore, QtWidgets
 import nuke
 import imp
 
@@ -32,7 +32,7 @@ class NukeWidget(QtWidgets.QWidget):
 
     def __init__(self, parent=None):
         super(NukeWidget, self).__init__(parent=parent)
-        pyside_utils.UiLoader.loadUi(self._ui_filepath, self)
+        QtCompat.loadUi(self._ui_filepath, baseinstance=self)
         self.refreshUi()
 
     def refreshUi(self):


### PR DESCRIPTION
Quick change to use more cross compatible [QtCompat.loadUi](https://github.com/mottosso/Qt.py#loading-qt-designer-files) from `Qt.py`

Removed `pyside_utils.UiLoader` class (was causing import errors for `PyQt*`)

Tested GUI opens on:
- [x] Maya 2018
- [x] Nuke 11.2


