### PR TITLE
Changed to QTreeWidgetItem.setHidden

### DIFF
--- a/conductor/submitter.py
+++ b/conductor/submitter.py
@@ -1443,12 +1443,12 @@ class ConductorSubmitter(QtWidgets.QMainWindow):
 #         host_product_info = self.getHostProductInfo()
 # #         item_groups = self.getTreeItemGroups()
 #         for host_package_item in self.getHostPackageTreeItems():
-#             self.ui_software_versions_trwgt.setItemHidden(host_package_item, True)
+#             host_package_item.setHidden(True)
 #             package = self.get_package_by_id(host_package_item.package_id)
 #             if package["product"] == self.product:
 #                 best_package = self.getBestPackage(host_product_info, self.software_packages.values())
 #                 if show_all_versions or (best_package and package["package_id"] == best_package["package_id"]):
-#                     self.ui_software_versions_trwgt.setItemHidden(host_package_item, False)
+#                     host_package_item.setHidden(False)
 
     def filterPackages(self, show_all_versions=False):
         host_package_info = self.getHostProductInfo()
@@ -1456,13 +1456,11 @@ class ConductorSubmitter(QtWidgets.QMainWindow):
         host_package = self.get_package_by_id(
             host_package_id) if host_package_id else None
         for host_package_item in self.getHostPackageTreeItems():
-            self.ui_software_versions_trwgt.setItemHidden(
-                host_package_item, True)
+            host_package_item.setHidden(True)
             package = self.get_package_by_id(host_package_item.package_id)
             if package["product"] == self.product:
                 if show_all_versions or not host_package or package == host_package:
-                    self.ui_software_versions_trwgt.setItemHidden(
-                        host_package_item, False)
+                    host_package_item.setHidden(False)
 
     def getTreeItemPackages(self):
         tree_item_packages = {}

--- a/conductor/submitter.py
+++ b/conductor/submitter.py
@@ -1593,7 +1593,7 @@ class ConductorSubmitter(QtWidgets.QMainWindow):
             self.ui_software_versions_trwgt.selectionModel().clear()
 
         for tree_item in tree_items:
-            self.ui_software_versions_trwgt.setItemSelected(tree_item, True)
+            tree_item.setSelected(True)
 
     ###########################################################################
     #  JOB SOFTWARE TREEWIDGET  - self.ui_job_software_trwgt

--- a/conductor/submitter_nuke.py
+++ b/conductor/submitter_nuke.py
@@ -56,7 +56,7 @@ class NukeWidget(QtWidgets.QWidget):
 
             # If the node is selected in Nuke, then select it in the UI
             if selected:
-                self.ui_write_nodes_trwgt.setItemSelected(tree_item, True)
+                tree_item.setSelected(True)
 
     def populateViews(self, views):
         '''
@@ -68,7 +68,7 @@ class NukeWidget(QtWidgets.QWidget):
         for view in views:
             tree_item = QtWidgets.QTreeWidgetItem([view])
             self.ui_views_trwgt.addTopLevelItem(tree_item)
-            self.ui_views_trwgt.setItemSelected(tree_item, True)
+            tree_item.setSelected(True)
 
         #  If there is only one view, disable this box...
         if len(views) == 1:


### PR DESCRIPTION
Made cross compatible with PyQt.

The old [QTreeWidget.setItemHidden](https://doc.qt.io/qtforpython/PySide2/QtWidgets/QTreeWidget.html#PySide2.QtWidgets.PySide2.QtWidgets.QTreeWidget.setItemHidden) will also be deprecated.

Same for [QTreeWidget.isItemSelected](https://doc.qt.io/qtforpython/PySide2/QtWidgets/QTreeWidget.html#PySide2.QtWidgets.PySide2.QtWidgets.QTreeWidget.isItemSelected)