### PR TITLE
Fix instance types for clarisse

### DIFF
--- a/conductor/clarisse/scripted_class/instances_ui.py
+++ b/conductor/clarisse/scripted_class/instances_ui.py
@@ -22,4 +22,6 @@ def update(obj, data_block):
     instance_type_att = obj.get_attribute("instance_type")
     instance_type_att.remove_all_presets()
     for i, instance_type in enumerate(instance_types):
-        instance_type_att.add_preset(instance_type["description"], str(i))
+        instance_type_att.add_preset(
+            instance_type["description"].encode("utf-8"), str(i)
+        )


### PR DESCRIPTION
Clarisse doesn't like using unicode strings to build its menus. In true Clarisse fashion, it just crashes. This PR converts them to `utf8`.