### PR TITLE
adds better naming, default title, instance sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+* **Clarisse submitter:** 
+  * Submitter title defaults to $PNAME
+  * Images attribute changed to images_and_layers
+  * instance types menu entries are now ordered by machine spec
+
 
 # v2.10.0  -  2019.09.23
 
@@ -17,24 +24,14 @@
   
 # v2.9.1  -  2019.08.30
 
-#### Added
-
-* **Clarisse > Layers:** Supports rendering of individual image layers without rendering the containing image.
-
-* **Clarisse > Missing dependencies:**  Allows you to proceed with a render if some dependencies are missing. You are shown a list of missing files first. Offending files are removed from the upload list, which would previously cause a submission failure.
-
-* **Clarisse > Upload clarisse.cfg:** Supports shipping of the clarisse.cfg file so that preferences such as "output AOV to separate files" are respected. It has been necessary to strip some UI-focused categories to avoid a crash on Windows.
-
-* **Clarisse > Localize contexts:** Allows you to choose between localizing contexts, or shipping the job with nested xrefs in tact. Due to a bug in the Clarisse undo mechanism after localizing contexts, the only way to restore the project previously was to reload a saved backup after submitting. Now we can handle shipping xrefs, there's no need to modify the scene before submission and therefore the whole operation is faster.
-
-* **Clarisse > Token substitution:** `<angle bracket tokens>` are now used to build the task command. The previous release used Clarisse `$VARIABLES` which could be confusing and less robust.
-
-* **Clarisse > CNODE arguments:** Some CLI args, like -license_server, -config_file, and -debug_level, have been moved into the wrapper in order to keep the task command clean. They are implemented as default values that make sense for submissions to the cloud, but can be overridden by simply including them in the task template.
-
-* **Clarisse > Path errors:**  Dependency scanning now has improved handling and information display when badly formed paths are encountered.
-
-* **Clarisse > Render package:**  Save a regular project to ship to Conductor, in favour of the now deprecated render package binary.
-
-* **Clarisse > Clarisse version:**  Removed the over-complicated tree view widget for software package selection in favor of a dropdown menu.
-
-* **Clarisse > Validate output path:**  If several images or layers are being rendered to different locations, we determine the writable output as the common location among them. If this path turns out to be the root path, it is considered invalid and.
+* **Clarisse:** 
+  * **Layers:** Supports rendering of individual image layers without rendering the containing image.
+  * **Missing files:** You can proceed with a render if some dependencies are missing. You are shown a list of missing files first. Offending files are removed from the upload list, which would previously cause a submission failure.
+  * **clarisse.cfg:** Supports shipping of the clarisse.cfg file so that preferences such as "output AOV to separate files" are respected. It has been necessary to strip some UI-focused categories to avoid a crash on Windows.
+  * **Localize contexts:** Choose between localizing contexts, or shipping the job with nested xrefs in tact. Due to a bug in the Clarisse undo mechanism after localizing contexts, the only way to restore the project previously was to reload a saved backup after submitting. Now we can handle shipping xrefs, there's no need to modify the scene before submission and therefore the whole operation is faster.
+  * **Token substitution:** `<angle bracket tokens>` are now used to build the task command. The previous release used Clarisse `$VARIABLES` which could be confusing and less robust.
+  * **CNODE arguments:** Some CLI args, like -license_server, -config_file, and -debug_level, have been moved into the wrapper in order to keep the task command clean. They are implemented as default values that make sense for submissions to the cloud, but can be overridden b,y including them in the task template.
+  * **Path errors:** Dependency scanning now has improved handling and information display when badly formed paths are encountered.
+  * Render package: Ship a regular project ASCII file to Conductor, in favour of the now deprecated render package binary.
+  * **Clarisse version:**  Removed the over-complicated tree view widget for software package selection in favor of a dropdown menu.
+  * **Validate output path:**  If several images or layers are being rendered to different locations, we determine the writable output as the common location among them. If this path turns out to be the root path, it is considered invalid.

--- a/conductor/clarisse/scripted_class/attr_docs.py
+++ b/conductor/clarisse/scripted_class/attr_docs.py
@@ -23,7 +23,7 @@ def set_docs(s_class):
     )
 
     s_class.set_attr_doc(
-        "images",
+        "images_and_layers",
         """Sets the items to be rendered. Images or Layers must have their Render to Disk attribute set. The Save As field must contain a filename.""",
     )
 

--- a/conductor/clarisse/scripted_class/conductor_job.py
+++ b/conductor/clarisse/scripted_class/conductor_job.py
@@ -27,7 +27,7 @@ DEFAULT_CMD_TEMPLATE += "-image <ct_sources> -image_frames_list <ct_chunks> "
 DEFAULT_CMD_TEMPLATE += "-tile_rendering <ct_tiles> <ct_tile_number>"
 
 
-DEFAULT_TITLE = "<ct_job>"
+DEFAULT_TITLE = "$PNAME"
 
 
 class ConductorJob(ix.api.ModuleScriptedClassEngine):
@@ -102,7 +102,7 @@ class ConductorJob(ix.api.ModuleScriptedClassEngine):
                 frames_ui.handle_scout_frames(obj, attr)
             elif attr_name == "chunk_size":
                 frames_ui.handle_chunk_size(obj, attr)
-            elif attr_name == "images":
+            elif attr_name == "images_and_layers":
                 frames_ui.handle_images(obj, attr)
             elif attr_name == "notify":
                 notifications_ui.notify_changed(obj, attr)
@@ -248,7 +248,7 @@ class ConductorJob(ix.api.ModuleScriptedClassEngine):
         attr.set_string(DEFAULT_TITLE)
 
         attr = s_class.add_attribute(
-            "images",
+            "images_and_layers",
             OfAttr.TYPE_REFERENCE,
             OfAttr.CONTAINER_LIST,
             OfAttr.VISUAL_HINT_DEFAULT,

--- a/conductor/clarisse/scripted_class/instances_ui.py
+++ b/conductor/clarisse/scripted_class/instances_ui.py
@@ -12,8 +12,6 @@ NOTE: In a future version we will also save the name of the instance type. This
 def update(obj, data_block):
     """
     Rebuilds the instance types menu. 
-    
-    Until we have a cost field, items are sorted by cores and memory.
 
     Args:
         obj (ConductorJob): Item on which to rebuild menu.

--- a/conductor/clarisse/scripted_class/instances_ui.py
+++ b/conductor/clarisse/scripted_class/instances_ui.py
@@ -11,7 +11,9 @@ NOTE: In a future version we will also save the name of the instance type. This
 
 def update(obj, data_block):
     """
-    Rebuilds the instance types menu.
+    Rebuilds the instance types menu. 
+    
+    Until we have a cost field, items are sorted by cores and memory.
 
     Args:
         obj (ConductorJob): Item on which to rebuild menu.
@@ -21,7 +23,9 @@ def update(obj, data_block):
     instance_types = data_block.instance_types()
     instance_type_att = obj.get_attribute("instance_type")
     instance_type_att.remove_all_presets()
-    for i, instance_type in enumerate(instance_types):
+    for i, instance_type in enumerate(
+        sorted(instance_types, key=lambda x: (x["cores"], x["memory"]))
+    ):
         instance_type_att.add_preset(
             instance_type["description"].encode("utf-8"), str(i)
         )

--- a/conductor/clarisse/scripted_class/submit_actions.py
+++ b/conductor/clarisse/scripted_class/submit_actions.py
@@ -161,7 +161,7 @@ def _validate_images(node):
         node (ConductorJob): Node
     """
     images = ix.api.OfObjectArray()
-    node.get_attribute("images").get_values(images)
+    node.get_attribute("images_and_layers").get_values(images)
     out_paths = PathList()
     if not images.get_count():
         ix.log_error("No render images. Please reference one or more image items")


### PR DESCRIPTION
Rename **images** attribute to be more descriptive.
Use an SExpr expression for the default job title (as opposed to an angle bracket token)
Sort **instance_type** menu on machine spec (cores/mem).
