### PR TITLE
Clarisse: Fix bad images attribute name. Make better pre-render windows path conversion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   * Submitter title defaults to $PNAME.
   * Images attribute changed to images_and_layers.
   * Instance types menu entries are now ordered by machine spec.
-  * Pre render script also replaces backslashes as well as drive letters.
+  * Pre render script replaces backslashes as well as drive letters.
   * Better error on failure to make subdirectories.
 
 # v2.10.0  -  2019.09.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
 
 * **Clarisse submitter:** 
-  * Submitter title defaults to $PNAME
-  * Images attribute changed to images_and_layers
-  * instance types menu entries are now ordered by machine spec
-
+  * Submitter title defaults to $PNAME.
+  * Images attribute changed to images_and_layers.
+  * Instance types menu entries are now ordered by machine spec.
+  * Pre render script also replaces backslashes as well as drive letters.
+  * Better error on failure to make subdirectories.
 
 # v2.10.0  -  2019.09.23
 

--- a/conductor/clarisse/scripted_class/frames_ui.py
+++ b/conductor/clarisse/scripted_class/frames_ui.py
@@ -140,7 +140,7 @@ def range_frame_sequence(obj):
     """
 
     images = ix.api.OfObjectArray()
-    obj.get_attribute("images").get_values(images)
+    obj.get_attribute("images_and_layers").get_values(images)
 
     seq = _union_sequence(list(images))
     if not seq:

--- a/conductor/clarisse/scripted_class/job.py
+++ b/conductor/clarisse/scripted_class/job.py
@@ -93,7 +93,7 @@ class Job(object):
         """
 
         images = ix.api.OfObjectArray()
-        self.node.get_attribute("images").get_values(images)
+        self.node.get_attribute("images_and_layers").get_values(images)
 
         use_custom = self.node.get_attribute("use_custom_frames").get_bool()
 
@@ -195,7 +195,7 @@ class Job(object):
         out_paths = PathList()
 
         images = ix.api.OfObjectArray()
-        self.node.get_attribute("images").get_values(images)
+        self.node.get_attribute("images_and_layers").get_values(images)
 
         for image in images:
             directory = os.path.dirname(image.get_attribute("save_as").get_string())


### PR DESCRIPTION
Issues fixed.
1. The images attribute was recently renamed, to images_and_layers, but a few instances slipped through the net, causing a crash on Windows.

2. A customed used backslashes in paths and they weren't converted in the prerender script, so the render crashed.

