### PR TITLE
Ct 1212 glob bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Unreleased
 
-* **Clarisse submitter:** 
+* **Clarisse submitter:**
+  * Catch invalid glob path that caused Clarisse to crash.
+
+# v2.10.4  -  2019.11.04
+
+* **Nuke Submitter:**
+    * Coerce Nuke's output_path format to Conductor expectations..
+
+# v2.10.3  -  2019.11.04
+
+* **Nuke Submitter:**
+    * Hotfix. add quotation marks around path.
+
+# v2.10.2  -  2019.10.31
+
+* **Maya Submitter:**
+    * Search .ass files for Image nodes and resolve relative paths.
+
+# v2.10.1  -  2019.09.26
+
+* **Clarisse submitter:**
   * Submitter title defaults to $PNAME.
   * Images attribute changed to images_and_layers.
   * Instance types menu entries are now ordered by machine spec.
@@ -9,23 +29,23 @@
 
 # v2.10.0  -  2019.09.23
 
-* **Submitter:** Instance type selection now supports Google Cloud's 
+* **Submitter:** Instance type selection now supports Google Cloud's
     * n1-standard-1
-    * n1-highcpu-2 
+    * n1-highcpu-2
     * n1-highcpu-4
 
-* **Package auto-matching support** 
-  * **Golaem:** 7.0.1 
-  * **Maya:** 2018.6, 2019, 2019.1, 2019.2 
+* **Package auto-matching support**
+  * **Golaem:** 7.0.1
+  * **Maya:** 2018.6, 2019, 2019.1, 2019.2
   * **Maya to Arnold:** 3.1.2.1, 3.1.2.2, 3.2.0, 3.2.0.1, 3.2.0.2, 3.2.1, 3.2.2, 3.2.1.1, 3.3.0
-  * **Nuke:** Nuke11.2v7, 11.3v5 
+  * **Nuke:** Nuke11.2v7, 11.3v5
   * **Renderman for Maya:** 21.8, 22.4, 22.5, 22.6
   * **V-Ray for Maya:** 4.04.03, 4.12.01, 4.12.02
   * **Yeti:** 3.1.15, 3.1.17, 3.5.1, 3.5.2
-  
+
 # v2.9.1  -  2019.08.30
 
-* **Clarisse:** 
+* **Clarisse:**
   * **Layers:** Supports rendering of individual image layers without rendering the containing image.
   * **Missing files:** You can proceed with a render if some dependencies are missing. You are shown a list of missing files first. Offending files are removed from the upload list, which would previously cause a submission failure.
   * **clarisse.cfg:** Supports shipping of the clarisse.cfg file so that preferences such as "output AOV to separate files" are respected. It has been necessary to strip some UI-focused categories to avoid a crash on Windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,10 @@
 * **Clarisse submitter:**
   * Catch invalid glob path that caused Clarisse to crash.
 
-# v2.10.4  -  2019.11.04
+# v2.11.1  -  2019.10.31
 
-* **Nuke Submitter:**
-    * Coerce Nuke's output_path format to Conductor expectations..
-
-# v2.10.3  -  2019.11.04
-
-* **Nuke Submitter:**
-    * Hotfix. add quotation marks around path.
-
-# v2.10.2  -  2019.10.31
-
-* **Maya Submitter:**
-    * Search .ass files for Image nodes and resolve relative paths.
+* **Uploader:**
+    * Support Uploading to AWS Buckets.
 
 # v2.10.1  -  2019.09.26
 

--- a/conductor/native/tests/test_gpath.py
+++ b/conductor/native/tests/test_gpath.py
@@ -16,8 +16,6 @@ NATIVE_MODULE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if NATIVE_MODULE not in sys.path:
     sys.path.insert(0, NATIVE_MODULE)
 
-sys.modules["glob"] = __import__("conductor.native.lib.mocks.glob", fromlist=["dummy"])
-
 
 class BadInputTest(unittest.TestCase):
     def test_badly_formed_drive_letter(self):

--- a/conductor/native/tests/test_gpath_list.py
+++ b/conductor/native/tests/test_gpath_list.py
@@ -226,6 +226,14 @@ class PathListTest(unittest.TestCase):
         d.glob()
         self.assertEqual(len(d), 20)
 
+    def test_glob_when_files_match_with_question_mark(self):
+        glob.populate(Sequence.create("1-20").expand("/some/file.####.exr"))
+        d = PathList()
+        file = "/some/file.00?0.exr"
+        d.add(file)
+        d.glob()
+        self.assertEqual(len(d), 2)
+
     def test_glob_when_files_match_with_range(self):
         glob.populate(Sequence.create("1-20").expand("/some/file.####.exr"))
         d = PathList()
@@ -233,14 +241,6 @@ class PathListTest(unittest.TestCase):
         d.add(file)
         d.glob()
         self.assertEqual(len(d), 9)
-
-    def test_glob_when_files_match_with_questoion_mark(self):
-        glob.populate(Sequence.create("1-20").expand("/some/file.####.exr"))
-        d = PathList()
-        file = "/some/file.00?0.exr"
-        d.add(file)
-        d.glob()
-        self.assertEqual(len(d), 2)
 
     def test_glob_dedups_when_many_files_match(self):
         glob.populate(Sequence.create("1-20").expand("/some/file.####.exr"))
@@ -270,6 +270,21 @@ class PathListTest(unittest.TestCase):
         d.add("/some/file.*.exr", "/other/file1.exr", "/other/file2.exr")
         d.glob()
         self.assertEqual(len(d), 5)
+
+    def test_ignore_invalid_glob(self):
+        bad_glob = "/path/to/Model[b-a]"
+        glob.populate(bad_glob)
+        d = PathList()
+        d.add(bad_glob)
+        d.glob()
+        self.assertEqual(list(d)[0].posix_path(), bad_glob)
+
+    def test_ignore_invalid_nonexistent_glob(self):
+        bad_glob = "/path/to/Model[b-a]"
+        d = PathList()
+        d.add(bad_glob)
+        d.glob()
+        self.assertEqual(list(d)[0].posix_path(), bad_glob)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed a bug experienced by Eric at Isotropix, where an invalid glob pattern was not caught and cause Clarisse to crash on windows. 

Also updated changelog and included an entry for Brian's AWS commit.

And in the second commit (6b11a18) I had accidentally added entries for commits that are not in master, so removed them.