### PR TITLE
Ct 1219 upload daemon cleanup bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
+* **Clarisse submitter:**
+  * Fixed bug where render file would be cleaned up before the upload daemon had a chance to upload it.
 
+# v2.11.1
 * **Clarisse submitter:**
   * Catch invalid glob path that caused Clarisse to crash.
 

--- a/conductor/clarisse/reloader.py
+++ b/conductor/clarisse/reloader.py
@@ -24,6 +24,7 @@ from conductor.clarisse.scripted_class import (
     submission,
     submit_actions,
     task,
+    upload_ui,
 )
 from conductor.native.lib import gpath, gpath_list, sequence
 
@@ -47,4 +48,5 @@ reload(projects_ui)
 reload(submission)
 reload(submit_actions)
 reload(preview_ui)
+reload(upload_ui)
 reload(attr_docs)

--- a/conductor/clarisse/scripted_class/attr_docs.py
+++ b/conductor/clarisse/scripted_class/attr_docs.py
@@ -78,7 +78,7 @@ def set_docs(s_class):
 
     s_class.set_attr_doc(
         "local_upload",
-        """Uploads files from your workstation, as opposed to using an upload daemon.""",
+        """Uploads files from your Clarisse session, as opposed to using an upload daemon.""",
     )
 
     s_class.set_attr_doc(
@@ -131,7 +131,7 @@ def set_docs(s_class):
 
     s_class.set_attr_doc(
         "clean_up_render_package",
-        """Removes the render project file after submission.""",
+        """Removes the render project file after submission. If local_upload is switched off, then this attribute will be hidden and the render project will not be removed.""",
     )
 
     s_class.set_attr_doc(

--- a/conductor/clarisse/scripted_class/conductor_job.py
+++ b/conductor/clarisse/scripted_class/conductor_job.py
@@ -18,6 +18,7 @@ from conductor.clarisse.scripted_class import (
     projects_ui,
     refresh,
     submit_actions,
+    upload_ui,
 )
 from conductor.lib import loggeria
 from conductor.native.lib.data_block import PROJECT_NOT_SET
@@ -110,6 +111,8 @@ class ConductorJob(ix.api.ModuleScriptedClassEngine):
                 notifications_ui.handle_email_addresses(obj, attr)
             elif attr_name == "conductor_log_level":
                 debug_ui.handle_log_level(obj, attr)
+            elif attr_name == "local_upload":
+                upload_ui.handle_local_upload(obj, attr)
             else:
                 pass
         except RuntimeError as ex:

--- a/conductor/clarisse/scripted_class/submission.py
+++ b/conductor/clarisse/scripted_class/submission.py
@@ -125,11 +125,13 @@ class Submission(object):
             )
         )
         self.render_package_path = self._get_render_package_path()
-        self.should_delete_render_package = self.node.get_attribute(
-            "clean_up_render_package"
-        ).get_bool()
-
         self.local_upload = self.node.get_attribute("local_upload").get_bool()
+
+        self.should_delete_render_package = (
+            self.node.get_attribute("clean_up_render_package").get_bool()
+            and self.local_upload
+        )
+
         self.force_upload = self.node.get_attribute("force_upload").get_bool()
         self.upload_only = self.node.get_attribute("upload_only").get_bool()
         self.project = self._get_project()

--- a/conductor/clarisse/scripted_class/upload_ui.py
+++ b/conductor/clarisse/scripted_class/upload_ui.py
@@ -1,7 +1,5 @@
 """
 Responds to events in the  upload section of the ConductorJob attribute editor.
-
-Currently, when 
 """
 
 import ix
@@ -11,13 +9,12 @@ def handle_local_upload(obj, attr):
     """
     Responds to local_upload changes.
 
-    We must not clean up the render file if local_upload is false, 
-    because it cleans up before the upload daemon has had a chance 
+    We must not clean up the render file if local_upload is false,
+    because it cleans up before the upload daemon has had a chance
     to upload it.
 
     Args:
         obj (ConductorJob):
         attr (OfAttr): Attribute that changed.
     """
-    hide_cleanup = not attr.get_bool()
-    obj.get_attribute("clean_up_render_package").set_hidden(hide_cleanup)
+    obj.get_attribute("clean_up_render_package").set_hidden(not attr.get_bool())

--- a/conductor/clarisse/scripted_class/upload_ui.py
+++ b/conductor/clarisse/scripted_class/upload_ui.py
@@ -1,0 +1,23 @@
+"""
+Responds to events in the  upload section of the ConductorJob attribute editor.
+
+Currently, when 
+"""
+
+import ix
+
+
+def handle_local_upload(obj, attr):
+    """
+    Responds to local_upload changes.
+
+    We must not clean up the render file if local_upload is false, 
+    because it cleans up before the upload daemon has had a chance 
+    to upload it.
+
+    Args:
+        obj (ConductorJob):
+        attr (OfAttr): Attribute that changed.
+    """
+    hide_cleanup = not attr.get_bool()
+    obj.get_attribute("clean_up_render_package").set_hidden(hide_cleanup)


### PR DESCRIPTION
In Clarisse submitter, we must not clean up the render file if local_upload is false, because it cleans up before the upload daemon has had a chance to upload it. For this reason, hide the option.