### PR TITLE
Ct 1223 clarisse offline path transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+* **Configuration file:** Fixed bug where empty config.yaml could not be parsed.
+
+# v2.11.6 -  2019.11.30
+
+* **Clarisse submitter:** 
+  * Better detection of windows paths to be replaced. Less chance of false positives.
 
 # v2.11.5 -  2019.11.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Unreleased
-* **Clarisse submitter:**
+
+# v2.11.4  -  2019.11.19
+
+* **Clarisse submitter:** 
+  * Now handles windows path management offline by replacing paths in project files. In some situations links to resources in files with nested references could get erased while loading a project if all the references are not resolved. For this reason, its not sufficient to replace the paths in the session with the clarrisse sdk. Paths must be valid before the project loads. 
   * Fixed bug where render file would be cleaned up before the upload daemon had a chance to upload it.
 
-# v2.11.1
+# v2.11.3  -  2019.11.14
+
 * **Clarisse submitter:**
   * Catch invalid glob path that caused Clarisse to crash.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+
+# v2.11.5 -  2019.11.25
+
+* **Clarisse submitter:** 
+  * Path manipulation code now runs on Windows only.
+
 # v2.11.4 -  2019.11.19
 
 * **Clarisse submitter:** 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# v2.11.4  -  2019.11.19
+# v2.11.4 -  2019.11.19
 
 * **Clarisse submitter:** 
   * Now handles windows path management offline by replacing paths in project files. In some situations links to resources in files with nested references could get erased while loading a project if all the references are not resolved. For this reason, its not sufficient to replace the paths in the session with the clarrisse sdk. Paths must be valid before the project loads. 

--- a/conductor/clarisse/scripted_class/conductor_job.py
+++ b/conductor/clarisse/scripted_class/conductor_job.py
@@ -25,8 +25,8 @@ from conductor.native.lib.data_block import PROJECT_NOT_SET
 
 DEFAULT_CMD_TEMPLATE = "<ct_temp_dir>/ct_cnode <ct_render_package> "
 DEFAULT_CMD_TEMPLATE += "-image <ct_sources> -image_frames_list <ct_chunks> "
-DEFAULT_CMD_TEMPLATE += "-tile_rendering <ct_tiles> <ct_tile_number>"
-
+DEFAULT_CMD_TEMPLATE += "-tile_rendering <ct_tiles> <ct_tile_number> "
+DEFAULT_CMD_TEMPLATE += "-license_server conductor_ilise:40500"
 
 DEFAULT_TITLE = "$PNAME"
 

--- a/conductor/clarisse/scripted_class/dependencies.py
+++ b/conductor/clarisse/scripted_class/dependencies.py
@@ -231,8 +231,8 @@ def get_scan(obj, policy, include_references=True):
     # 2. Getting ref contexts from OfAttr.get_path_attrs() is buggy so it's best
     #    to get them through the root context with resolve_all_contexts()
 
-    # We convert all project refverences to a conductor version because we will
-    # be replacing them. (Windows)
+    # We make a new extension for all project reference paths (".ct.project")
+    # because we will be replacing them with a linuxified version of the file.
     if include_references:
         refs = _scan_for_references()
         for ref in refs:

--- a/conductor/clarisse/scripted_class/dependencies.py
+++ b/conductor/clarisse/scripted_class/dependencies.py
@@ -125,6 +125,7 @@ def collect(obj):
 
     result.add(*_get_system_dependencies())
     result.add(*_get_extra_uploads(obj))
+
     result.add(*get_scan(obj, policy, include_references))
 
     # tell the list to look on disk and expand  any "*" or <UDIM> in place
@@ -229,8 +230,21 @@ def get_scan(obj, policy, include_references=True):
     #    (include_references==True).
     # 2. Getting ref contexts from OfAttr.get_path_attrs() is buggy so it's best
     #    to get them through the root context with resolve_all_contexts()
+
+    # We convert all project refverences to a conductor version because we will
+    # be replacing them. (Windows)
     if include_references:
-        result.add(*_scan_for_references())
+        refs = _scan_for_references()
+        for ref in refs:
+            if ref.endswith(".project"):
+                result.add(
+                    re.sub(
+                        r"(\.ct\.project|\.project)", ".ct.project", ref.posix_path()
+                    )
+                )
+            else:
+                result.add(ref)
+
     return result
 
 

--- a/conductor/clarisse/scripted_class/dependencies.py
+++ b/conductor/clarisse/scripted_class/dependencies.py
@@ -5,6 +5,7 @@ Collect dependencies
 import os
 import re
 
+import conductor.clarisse.utils as cu
 import ix
 from conductor.clarisse.scripted_class import frames_ui
 from conductor.native.lib.gpath import Path
@@ -235,7 +236,7 @@ def get_scan(obj, policy, include_references=True):
     # because we will be replacing them with a linuxified version of the file.
     if include_references:
         refs = _scan_for_references()
-        if os.name == "nt":
+        if cu.is_windows():
             for ref in refs:
                 if ref.endswith(".project"):
                     result.add(

--- a/conductor/clarisse/scripted_class/dependencies.py
+++ b/conductor/clarisse/scripted_class/dependencies.py
@@ -231,19 +231,24 @@ def get_scan(obj, policy, include_references=True):
     # 2. Getting ref contexts from OfAttr.get_path_attrs() is buggy so it's best
     #    to get them through the root context with resolve_all_contexts()
 
-    # We make a new extension for all project reference paths (".ct.project")
+    # On Windows, we make a new extension for all project reference paths (".ct.project")
     # because we will be replacing them with a linuxified version of the file.
     if include_references:
         refs = _scan_for_references()
-        for ref in refs:
-            if ref.endswith(".project"):
-                result.add(
-                    re.sub(
-                        r"(\.ct\.project|\.project)", ".ct.project", ref.posix_path()
+        if os.name == "nt":
+            for ref in refs:
+                if ref.endswith(".project"):
+                    result.add(
+                        re.sub(
+                            r"(\.ct\.project|\.project)",
+                            ".ct.project",
+                            ref.posix_path(),
+                        )
                     )
-                )
-            else:
-                result.add(ref)
+                else:
+                    result.add(ref)
+        else:
+            result.add(*refs)
 
     return result
 

--- a/conductor/clarisse/scripted_class/preview_ui.py
+++ b/conductor/clarisse/scripted_class/preview_ui.py
@@ -4,9 +4,9 @@ This is required because Clarisse's attribute editor doesn't allow
 custom UI to be embedded.
 """
 
-
 import json
 import ix
+import os
 import conductor.clarisse.utils as cu
 
 C_LEFT = ix.api.GuiWidget.CONSTRAINT_LEFT
@@ -149,7 +149,8 @@ class PreviewWindow(ix.api.GuiWindow):
         """
         with cu.waiting_cursor():
             self.submission.write_render_package()
-            self.submission.linuxify_project_files()
+            if os.name == "nt":
+                self.submission.linuxify_project_files()
 
     def on_go_but(self, sender, eventid):
         """

--- a/conductor/clarisse/scripted_class/preview_ui.py
+++ b/conductor/clarisse/scripted_class/preview_ui.py
@@ -5,9 +5,10 @@ custom UI to be embedded.
 """
 
 import json
-import ix
 import os
+
 import conductor.clarisse.utils as cu
+import ix
 
 C_LEFT = ix.api.GuiWidget.CONSTRAINT_LEFT
 C_TOP = ix.api.GuiWidget.CONSTRAINT_TOP
@@ -149,7 +150,7 @@ class PreviewWindow(ix.api.GuiWindow):
         """
         with cu.waiting_cursor():
             self.submission.write_render_package()
-            if os.name == "nt":
+            if cu.is_windows():
                 self.submission.linuxify_project_files()
 
     def on_go_but(self, sender, eventid):

--- a/conductor/clarisse/scripted_class/preview_ui.py
+++ b/conductor/clarisse/scripted_class/preview_ui.py
@@ -149,6 +149,7 @@ class PreviewWindow(ix.api.GuiWindow):
         """
         with cu.waiting_cursor():
             self.submission.write_render_package()
+            self.submission.linuxify_project_files()
 
     def on_go_but(self, sender, eventid):
         """

--- a/conductor/clarisse/scripted_class/refresh.py
+++ b/conductor/clarisse/scripted_class/refresh.py
@@ -44,7 +44,15 @@ def refresh(_, **kw):
     """
 
     kw["product"] = "clarisse"
-    data_block = ConductorDataBlock(**kw)
+    try:
+        data_block = ConductorDataBlock(**kw)
+    except:
+        ix.log_error(
+            """
+Can't get data from Conductor. Your credentials file may be corrupt.
+Please delete it from here (~/.config/conductor/credentials) and try again.
+            """
+        )
     nodes = ix.api.OfObjectArray()
     ix.application.get_factory().get_all_objects("ConductorJob", nodes)
 

--- a/conductor/clarisse/scripted_class/submission.py
+++ b/conductor/clarisse/scripted_class/submission.py
@@ -55,7 +55,9 @@ from conductor.native.lib.data_block import ConductorDataBlock
 from conductor.native.lib.gpath import Path
 from conductor.native.lib.gpath_list import PathList
 
-WIN_PROJECT_REGEX = r'.*"([A-Za-z]:(/|\\).*\.project)"'
+PROJECT_PATH_REGEX = r'.*".*\.project"'
+
+WIN_PROJECT_REGEX = r'.*"(([A-Za-z]:)?(/|\\).*\.project)"'
 WIN_PATH_REGEX = r'.*"([A-Za-z]:(/|\\).*)"'
 PROJECT_EXTENSION_REGEX = r"(\.ct\.project|\.project)"
 CT_PROJECT_EXTENSION = ".ct.project"
@@ -408,6 +410,7 @@ class Submission(object):
         Returns:
             string: The line to write
         """
+
         match = re.match(WIN_PROJECT_REGEX, line)
         if match:
             ix.log_info("MATCHING LINE: {}".format(line))

--- a/conductor/clarisse/scripted_class/submission.py
+++ b/conductor/clarisse/scripted_class/submission.py
@@ -55,8 +55,8 @@ from conductor.native.lib.data_block import ConductorDataBlock
 from conductor.native.lib.gpath import Path
 from conductor.native.lib.gpath_list import PathList
 
-WIN_PROJECT_REGEX = r'.*"([A-Z]:(/|\\).*\.project)"'
-WIN_PATH_REGEX = r'.*"([A-Z]:(/|\\).*)"'
+WIN_PROJECT_REGEX = r'.*"([A-Za-z]:(/|\\).*\.project)"'
+WIN_PATH_REGEX = r'.*"([A-Za-z]:(/|\\).*)"'
 PROJECT_EXTENSION_REGEX = r"(\.ct\.project|\.project)"
 CT_PROJECT_EXTENSION = ".ct.project"
 

--- a/conductor/clarisse/scripted_class/submission.py
+++ b/conductor/clarisse/scripted_class/submission.py
@@ -56,6 +56,12 @@ from conductor.native.lib.gpath_list import PathList
 PROJECT_EXTENSION_REGEX = r"(\.ct\.project|\.project)"
 CT_PROJECT_EXTENSION = ".ct.project"
 
+FILE_ATTR_HINTS = [
+    ix.api.OfAttr.VISUAL_HINT_FILENAME_SAVE,
+    ix.api.OfAttr.VISUAL_HINT_FILENAME_OPEN,
+    ix.api.OfAttr.VISUAL_HINT_FOLDER,
+]
+
 
 def _get_path_line_regex():
     """
@@ -69,19 +75,13 @@ def _get_path_line_regex():
     file_attrs = []
     for klass in classes.get_classes():
         attr_count = klass.get_attribute_count()
-        for i in range(attr_count):
+        for i in xrange(attr_count):
             attr = klass.get_attribute(i)
             hint = attr.get_visual_hint()
-            if hint in [
-                ix.api.OfAttr.VISUAL_HINT_FILENAME_SAVE,
-                ix.api.OfAttr.VISUAL_HINT_FILENAME_OPEN,
-                ix.api.OfAttr.VISUAL_HINT_FOLDER,
-            ]:
+            if hint in FILE_ATTR_HINTS:
                 file_attrs.append(attr.get_name())
 
-    file_attrs = list(set(file_attrs))
-    file_attrs.sort()
-    return r"\s+(?:" + "|".join(file_attrs) + r')\s+"(.*)"\s+'
+    return r"\s+(?:" + "|".join(sorted(set(file_attrs))) + r')\s+"(.*)"\s+'
 
 
 def _localize_contexts():
@@ -422,7 +422,7 @@ class Submission(object):
         """
         Fix paths for one file.
 
-        If the file already has the .ct.project extension, replace it too,
+        If the file already has the .ct.project extension, replace it too.
         """
         out_filename = dest_path
         if not dest_path:

--- a/conductor/clarisse/scripted_class/submission.py
+++ b/conductor/clarisse/scripted_class/submission.py
@@ -34,22 +34,18 @@ the localize method is the fallback.
 
 import datetime
 import errno
+import fileinput
 import os
-import shutil
-import tempfile
-
-import sys
 import re
-
+import shutil
+import sys
+import tempfile
 import traceback
 
-import ix
-
-import fileinput
-
+import conductor.clarisse.clarisse_config as ccfg
 import conductor.clarisse.scripted_class.dependencies as deps
 import conductor.clarisse.utils as cu
-import conductor.clarisse.clarisse_config as ccfg
+import ix
 from conductor.clarisse.scripted_class import missing_files_ui
 from conductor.clarisse.scripted_class.job import Job
 from conductor.lib import conductor_submit
@@ -340,7 +336,7 @@ class Submission(object):
         rendered on linux render nodes.
         """
         self.write_render_package()
-        if os.name == "nt":
+        if cu.is_windows():
             self._linuxify_project_references()
             self._linuxify_render_package()
 

--- a/conductor/clarisse/scripted_class/submission.py
+++ b/conductor/clarisse/scripted_class/submission.py
@@ -408,20 +408,20 @@ class Submission(object):
         Returns:
             string: The line to write
         """
-        win_project_match = re.match(WIN_PROJECT_REGEX, line)
-        win_path_match = re.match(WIN_PATH_REGEX, line)
-
-        if win_project_match:
+        match = re.match(WIN_PROJECT_REGEX, line)
+        if match:
             ix.log_info("MATCHING LINE: {}".format(line))
             path = re.sub(
                 PROJECT_EXTENSION_REGEX,
                 CT_PROJECT_EXTENSION,
-                Path(win_project_match.group(1)).posix_path(with_drive=False),
+                Path(match.group(1)).posix_path(with_drive=False),
             )
-            line = line.replace(win_project_match.group(1), path)
-        elif win_path_match:
-            path = Path(win_path_match.group(1)).posix_path(with_drive=False)
-            line = line.replace(win_path_match.group(1), path)
+            return line.replace(match.group(1), path)
+
+        match = re.match(WIN_PATH_REGEX, line)
+        if match:
+            path = Path(match.group(1)).posix_path(with_drive=False)
+            return line.replace(match.group(1), path)
 
         return line
 

--- a/conductor/clarisse/scripted_class/submission.py
+++ b/conductor/clarisse/scripted_class/submission.py
@@ -36,6 +36,8 @@ import datetime
 import errno
 import os
 import shutil
+import tempfile
+
 import sys
 import re
 
@@ -55,10 +57,35 @@ from conductor.native.lib.data_block import ConductorDataBlock
 from conductor.native.lib.gpath import Path
 from conductor.native.lib.gpath_list import PathList
 
-
-PATH_LINE_REGEX = r'\s+(?:filename|filename_sys|save_as)\s+"(.*)"\s+'
 PROJECT_EXTENSION_REGEX = r"(\.ct\.project|\.project)"
 CT_PROJECT_EXTENSION = ".ct.project"
+
+
+def _get_path_line_regex():
+    """
+    Generate a regex to help identify filepath attributes.
+
+    As we scan project files to replace windows paths, we use this regex which
+    will be something like: r'\s+(?:filename|filename_sys|save_as)\s+"(.*)"\s+' 
+    only longer.
+    """
+    classes = ix.application.get_factory().get_classes()
+    file_attrs = []
+    for klass in classes.get_classes():
+        attr_count = klass.get_attribute_count()
+        for i in range(attr_count):
+            attr = klass.get_attribute(i)
+            hint = attr.get_visual_hint()
+            if hint in [
+                ix.api.OfAttr.VISUAL_HINT_FILENAME_SAVE,
+                ix.api.OfAttr.VISUAL_HINT_FILENAME_OPEN,
+                ix.api.OfAttr.VISUAL_HINT_FOLDER,
+            ]:
+                file_attrs.append(attr.get_name())
+
+    file_attrs = list(set(file_attrs))
+    file_attrs.sort()
+    return r"\s+(?:" + "|".join(file_attrs) + r')\s+"(.*)"\s+'
 
 
 def _localize_contexts():
@@ -314,7 +341,8 @@ class Submission(object):
         """
         self.write_render_package()
         if os.name == "nt":
-            self.linuxify_project_files()
+            self._linuxify_project_references()
+            self._linuxify_render_package()
 
     def write_render_package(self):
         """
@@ -344,18 +372,19 @@ class Submission(object):
         ix.log_info("Wrote package to {}".format(package_file))
         return package_file
 
-    def linuxify_project_files(self):
+    def _linuxify_project_references(self):
         """
         Make copies of project files on Windows that are suitable for linux.
 
         Copies have the special conductor extension: ".ct.project".
         We convert all paths to posix. We also adjust references to
-        other projects to point to the ".ct.project" version.
+        other projects to point to the ".ct.project" version, because the 
+        .ct.project version will also be linuxified.
 
         """
         ix.log_info("Adjust project references for Linux")
         paths = PathList()
-        paths.add(self.render_package_path)
+
         contexts = ix.api.OfContextSet()
         ix.application.get_factory().get_root().resolve_all_contexts(contexts)
         for context in contexts:
@@ -373,34 +402,44 @@ class Submission(object):
 
         # Now we have a list of all filenames that need to be adjusted.
         # So we rewrite each file, and any references to other files they may contain.
+        PATH_LINE_REGEX = _get_path_line_regex()
         for path in paths:
             ix.log_info("Adjust paths in {}".format(path.posix_path()))
-            self._linuxify_file(path)
+            self._linuxify_file(path.posix_path(), PATH_LINE_REGEX)
 
-    def _linuxify_file(self, path):
+    def _linuxify_render_package(self):
+        """
+        Adjust reference pasths for windows.
+        """
+        PATH_LINE_REGEX = _get_path_line_regex()
+        temp_path = os.path.join(
+            tempfile.gettempdir(), next(tempfile._get_candidate_names())
+        )
+        shutil.copy2(self.render_package_path.posix_path(), temp_path)
+
+        os.remove(self.render_package_path.posix_path())
+        self._linuxify_file(
+            temp_path, PATH_LINE_REGEX, self.render_package_path.posix_path()
+        )
+
+    def _linuxify_file(self, filename, path_regex, dest_path=None):
         """
         Fix paths for one file.
 
-        If the file already has the .ct.project extension, overwrite it,
-        (so we don't end up with .ct.ct.ct.ct.project)
-        Otherwise create a new file with ".ct" in it.
+        If the file already has the .ct.project extension, replace it too,
         """
-        filename = path.posix_path()
-        out_filename = re.sub(
-            PROJECT_EXTENSION_REGEX, CT_PROJECT_EXTENSION, path.posix_path()
-        )
-        ix.log_info("{} -> {}".format(filename, out_filename))
+        out_filename = dest_path
+        if not dest_path:
+            out_filename = re.sub(
+                PROJECT_EXTENSION_REGEX, CT_PROJECT_EXTENSION, filename
+            )
 
-        if out_filename == filename:
-            for line in fileinput.input(filename, inplace=True):
-                sys.stdout.write(self._replace_path(line))
-        else:
-            with open(out_filename, "w+") as outfile:
-                with open(filename, "r+") as infile:
-                    for line in infile:
-                        outfile.write(self._replace_path(line))
+        with open(out_filename, "w+") as outfile:
+            with open(filename, "r+") as infile:
+                for line in infile:
+                    outfile.write(self._replace_path(line, path_regex))
 
-    def _replace_path(self, line):
+    def _replace_path(self, line, path_regex):
         """
         Detect paths in the line of text and make a replacement.
 
@@ -411,7 +450,7 @@ class Submission(object):
             string: The line, possibly with replaced path
         """
 
-        match = re.match(PATH_LINE_REGEX, line)
+        match = re.match(path_regex, line)
         if match:
             path = Path(match.group(1), no_expand=True).posix_path(with_drive=False)
             path = re.sub(PROJECT_EXTENSION_REGEX, CT_PROJECT_EXTENSION, path)

--- a/conductor/clarisse/scripted_class/submit_actions.py
+++ b/conductor/clarisse/scripted_class/submit_actions.py
@@ -109,8 +109,7 @@ def submit(*args):
     if state not in [SAVE_STATE_UNMODIFIED, SAVE_STATE_SAVED, SAVE_STATE_DONT_CARE]:
         ix.log_warning("Submission cancelled.")
         return
-    _validate_images(node)
-    _validate_packages(node)
+    _validate(node)
 
     with cu.waiting_cursor():
         submission = Submission(node)

--- a/conductor/clarisse/scripts/ct_cnode
+++ b/conductor/clarisse/scripts/ct_cnode
@@ -144,14 +144,7 @@ def main():
     cnode_args = ["cnode"] + pass_through_args
 
     # Add some defaults.
-    cnode_args += [
-        "-config_file",
-        args.config_file,
-        # "-license_server",
-        # args.license_server,
-        "-log_width",
-        str(args.log_width),
-    ]
+    cnode_args += ["-config_file", args.config_file, "-log_width", str(args.log_width)]
 
     # Adds a tile rendering flag only if there are actually multiple tiles. We
     # don't want to add the flag in the case of one tile, because it will put

--- a/conductor/clarisse/scripts/ct_cnode
+++ b/conductor/clarisse/scripts/ct_cnode
@@ -115,16 +115,6 @@ def main():
         help="Specify the config file used by CNODE. (default: %(default)s)",
     )
 
-    # Unlikely this will be overridden, but until corev2.1 works the same as
-    # legacy, we'll need to override it with the hyphenated version of the
-    # server name.
-    parser.add_argument(
-        "-license_server",
-        type=str,
-        default="conductor_ilise:40500",
-        help="Specify ILISE license server network location. (default: %(default)s)",
-    )
-
     # Logs in the Conductor UI are more readable when not wrapped at 80 columns.
     parser.add_argument(
         "-log_width",
@@ -157,8 +147,8 @@ def main():
     cnode_args += [
         "-config_file",
         args.config_file,
-        "-license_server",
-        args.license_server,
+        # "-license_server",
+        # args.license_server,
         "-log_width",
         str(args.log_width),
     ]

--- a/conductor/clarisse/scripts/ct_prep.py
+++ b/conductor/clarisse/scripts/ct_prep.py
@@ -1,7 +1,5 @@
 """
 Pre render script to run inside clarisse on the render node.
-
-Strips drive letters on windows. 
 Ensures images are renderable for the given range.
 Ensures directories exist for renders.
 """
@@ -17,20 +15,6 @@ import ix
 LETTER_RX = re.compile(r"^([a-zA-Z]):")
 
 
-@contextmanager
-def disabled_app():
-    """
-    Run functions in the app while disabled.
-
-    Clarisse crashes while resolving drive letters in contexts unless the
-    operation is done while disabled.
-    """
-    app = ix.application
-    app.disable()
-    yield
-    app.enable()
-
-
 def main():
     """
     Prepare this project to be rendered.
@@ -39,113 +23,18 @@ def main():
     parser = argparse.ArgumentParser(description=desc)
 
     parser.add_argument(
-        "-convert_windows_paths",
-        action="store_true",
-        default=True,
-        help="If this was submitted from windows, strip drive letters.",
-    )
-
-    parser.add_argument(
         "-range", nargs=2, type=int, help="Ensure image ranges are turned on."
     )
 
     parser.add_argument("-images", nargs="+", type=str, help="Image object names.")
 
     options, _ = parser.parse_known_args()
-    ix.log_info("convert_windows_paths {}".format(options.convert_windows_paths))
-
-    resolve_contexts()
-
-    # strip regular drive letters AFTER resolving contexts so we catch any paths
-    # that were inside contexts.
-    if options.convert_windows_paths:
-        convert_windows_paths()
 
     if options.range and options.images:
         start, end = options.range
         force_image_ranges(start, end, options.images)
 
-    ensure_image_directories(options.images)
-
-
-def resolve_contexts():
-    """
-    Find the root context and recurse down, resolving xrefs in children.
-
-    If a context (A) is a reference to another file and that file
-    contains a reference context (B), and A's filepath is wrong, then we
-    don't know anything about B, so we can't gather all contexts in one
-    hit and replace drive letters. We must recurse down, and for each
-    reference context, resolve its path and then visit the contexts it
-    contains.
-
-    We have to disable the app for this operation otherwise it tends to crash Clarisse.
-    """
-    contexts = ix.api.OfContextSet()
-    ix.application.get_factory().get_root().resolve_all_contexts(contexts)
-    with disabled_app():
-        resolve(contexts[0])
-
-
-def resolve(ctx):
-    """
-    Recursively fix windows paths in xref contexts and discover their children.
-
-    Args:
-        ctx (OfContext): parent context.
-    """
-    level = ctx.get_level()
-
-    if ctx.is_reference():
-        attr = ctx.get_attribute("filename")
-        convert_windows_path(attr)
-
-    next_level = level + 1
-    contexts = ix.api.OfContextSet()
-    ctx.resolve_all_contexts(contexts)
-    for ctx in [c for c in list(contexts) if c.get_level() == next_level]:
-        resolve(ctx)
-
-
-def convert_windows_paths():
-    """
-    Fix windows paths in regular path attrs.
-    """
-    attrs = ix.api.OfAttr.get_path_attrs()
-    total = len(list(attrs))
-    ix.log_info("Stripping drive letters for {:d} paths".format(total))
-    count = 0
-    for attr in attrs:
-        if convert_windows_path(attr):
-            count += 1
-    ix.log_info("Done conforming {:d} of {:d} paths".format(count, total))
-
-
-def convert_windows_path(attr):
-    """
-    Fix windows paths in one path attribute.
-
-    Args:
-        attr (OfAttr): Attribute to modify.
-
-    Returns:
-        bool: Whether the attribute was modified
-    """
-    path = attr.get_string()
-    attr_name = attr.get_name()
-    item_name = attr.get_parent_object().get_name()
-
-    if path:
-        result = re.sub(LETTER_RX, "", path).replace("\\", "/")
-        if result == path:
-            ix.log_info("Path OK: {}.{} {}".format(item_name, attr_name, path))
-        else:
-            attr.set_string(result)
-            ix.log_info(
-                "Conformed: {}.{} {} -> {}".format(item_name, attr_name, path, result)
-            )
-            return True
-    return False
+        ensure_image_directories(options.images)
 
 
 def force_image_ranges(start, end, images):

--- a/conductor/clarisse/scripts/ct_prep.py
+++ b/conductor/clarisse/scripts/ct_prep.py
@@ -79,7 +79,7 @@ def ensure_image_directories(images):
         directory = os.path.dirname(image.get_attribute("save_as").get_string())
         directories.append(directory)
         sys.stdout.write("{} save to disk at: {}\n".format(image_path, directory))
-    mkdir_p(directories)
+    mkdir_p(list(set(directories)))
 
 
 def mkdir_p(dirs):
@@ -100,7 +100,9 @@ def mkdir_p(dirs):
                 pass
             else:
                 sys.stderr.write(
-                    "There's something wrong with the path: ('{}')\n".format(d)
+                    "There's something wrong with the path: ('{}'), : {}\n".format(
+                        d, os.strerror(ex.errno)
+                    )
                 )
                 raise
 

--- a/conductor/clarisse/utils.py
+++ b/conductor/clarisse/utils.py
@@ -1,6 +1,7 @@
 """
 Contexts for performing long or delicate functions.
 """
+import os
 from contextlib import contextmanager
 
 import ix
@@ -27,3 +28,7 @@ def disabled_app():
     app.disable()
     yield
     app.enable()
+
+
+def is_windows():
+    return os.name == "nt"

--- a/conductor/native/lib/gpath.py
+++ b/conductor/native/lib/gpath.py
@@ -97,6 +97,9 @@ class Path(object):
     def startswith(self, path):
         return self.posix_path().startswith(path.posix_path())
 
+    def endswith(self, suffix):
+        return self.posix_path().endswith(suffix)
+
     def __len__(self):
         return len(self.posix_path())
 
@@ -129,4 +132,4 @@ class Path(object):
 
     @property
     def tail(self):
-        return self._components[-1]
+        return self._components[-1] if self._components else None

--- a/conductor/native/lib/gpath.py
+++ b/conductor/native/lib/gpath.py
@@ -1,4 +1,5 @@
 import os
+
 import re
 
 RX_LETTER = re.compile(r"^([a-zA-Z]):")
@@ -37,7 +38,9 @@ class Path(object):
         """Initialize a generic absolute path.
 
         If path is a list, then each element will be a component of the path. 
-        If it's a string then expand context variables, env vars and user. 
+        If it's a string then expand context variables.
+        Also expand, env vars and user unless explicitly told not to with the
+        no_expand option. 
         """
 
         if not path:
@@ -47,22 +50,23 @@ class Path(object):
             ipath = path[:]
             self._drive_letter = ipath.pop(0)[0] if RX_LETTER.match(ipath[0]) else None
             self._components = _normalize_dots(ipath)
+            self._absolute = True
         else:
             context = kw.get("context")
             if context:
                 path = _expand_context(path, context)
-            path = os.path.expanduser(os.path.expandvars(path))
+
+            if not kw.get("no_expand", False):
+                path = os.path.expanduser(os.path.expandvars(path))
 
             match = RX_LETTER.match(path)
             self._drive_letter = match.group(1) if match else None
             remainder = re.sub(RX_LETTER, "", path)
 
-            if remainder[0] not in ["/", "\\"]:
-                raise ValueError(
-                    "Not an absolute path. Starts with: '{}'".format(remainder[0])
-                )
-            if any((c in [":"]) for c in remainder):
-                raise ValueError("Bad characters in path:{}".format(remainder))
+            self._absolute = remainder[0] in ["/", "\\"]
+
+            if ":" in remainder:
+                raise ValueError("Bad characters in path '{}'".format(remainder))
 
             self._components = _normalize_dots(
                 [s for s in re.split("/|\\\\", remainder) if s]
@@ -72,7 +76,9 @@ class Path(object):
 
     def _construct_path(self, sep, with_drive_letter=True):
         """Reconstruct path for given path sep."""
-        result = "{}{}".format(sep, sep.join(self._components))
+        result = sep.join(self._components)
+        if self._absolute:
+            result = "{}{}".format(sep, result)
         if with_drive_letter and self._drive_letter:
             result = "{}:{}".format(self._drive_letter, result)
         return result
@@ -118,6 +124,14 @@ class Path(object):
     @property
     def drive_letter(self):
         return self._drive_letter or ""
+
+    @property
+    def absolute(self):
+        return self._absolute
+
+    @property
+    def relative(self):
+        return not self._absolute
 
     @property
     def components(self):

--- a/conductor/native/tests/test_gpath.py
+++ b/conductor/native/tests/test_gpath.py
@@ -241,5 +241,23 @@ class PathCollapseDotsTest(unittest.TestCase):
             Path("/a/b/../../../")
 
 
+class PathComponentsTest(unittest.TestCase):
+    def test_path_gets_tail(self):
+        p = Path("/a/b/c")
+        self.assertEqual(p.tail, "c")
+
+    def test_path_gets_none_when_no_tail(self):
+        p = Path("/")
+        self.assertEqual(p.tail, None)
+
+    def test_path_ends_with(self):
+        p = Path("/a/b/cdef")
+        self.assertTrue(p.endswith("ef"))
+
+    def test_path_not_ends_with(self):
+        p = Path("/a/b/cdef")
+        self.assertFalse(p.endswith("eg"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/conductor/native/tests/test_gpath.py
+++ b/conductor/native/tests/test_gpath.py
@@ -30,16 +30,6 @@ class BadInputTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.p = Path("A:a\\b:c")
 
-    def test_relative_input_literal(self):
-        with self.assertRaises(ValueError):
-            self.p = Path("a/b/c")
-
-    def test_relative_input_var(self):
-        env = {"DEPT": "texturing"}
-        with mock.patch.dict("os.environ", env):
-            with self.assertRaises(ValueError):
-                self.p = Path("$DEPT/a/b/c")
-
 
 class RootPath(unittest.TestCase):
     def test_root_path(self):
@@ -147,6 +137,28 @@ class PathExpansionTest(unittest.TestCase):
             self.assertEqual(self.p.windows_path(), "\\users\\joebloggs\\a\\b\\c")
             self.assertEqual(self.p.posix_path(), "/users/joebloggs/a/b/c")
 
+    def test_tilde_no_expand(self):
+        with mock.patch.dict("os.environ", self.env):
+            self.p = Path("~/a/b/c", no_expand=True)
+            self.assertEqual(self.p.posix_path(), "~/a/b/c")
+
+    def test_posix_var_no_expand(self):
+        with mock.patch.dict("os.environ", self.env):
+            self.p = Path("$SHOT/a/b/c", no_expand=True)
+            self.assertEqual(self.p.posix_path(), "$SHOT/a/b/c")
+
+    def no_expand_variable_considered_relative(self):
+        with mock.patch.dict("os.environ", self.env):
+            self.p = Path("$SHOT/a/b/c", no_expand=True)
+            self.assertTrue(self.p.relative)
+            self.assertFalse(self.p.absolute)
+
+    def expanded_variable_considered_absolute(self):
+        with mock.patch.dict("os.environ", self.env):
+            self.p = Path("$SHOT/a/b/c", no_expand=False)
+            self.assertFalse(self.p.relative)
+            self.assertTrue(self.p.absolute)
+
 
 class PathContextExpansionTest(unittest.TestCase):
     def setUp(self):
@@ -182,10 +194,6 @@ class PathContextExpansionTest(unittest.TestCase):
             self.p.posix_path(), "/some/root/bar_fly1_val/fooval/thefile.$F.jpg"
         )
 
-    def test_relative_path_var_fails(self):
-        with self.assertRaises(ValueError):
-            self.p = Path("$FOO/a/b/c", context=self.context)
-
 
 class PathLengthTest(unittest.TestCase):
     def test_len_with_drive_letter(self):
@@ -202,6 +210,10 @@ class PathLengthTest(unittest.TestCase):
 
     def test_depth_with_no_drive_letter(self):
         self.p = Path("\\aaa\\bbb/c")
+        self.assertEqual(self.p.depth, 3)
+
+    def test_depth_with_literal_rel_path(self):
+        self.p = Path("aaa\\bbb/c")
         self.assertEqual(self.p.depth, 3)
 
 
@@ -257,6 +269,12 @@ class PathComponentsTest(unittest.TestCase):
     def test_path_not_ends_with(self):
         p = Path("/a/b/cdef")
         self.assertFalse(p.endswith("eg"))
+
+
+class RelativePathTest(unittest.TestCase):
+    def test_rel_path_does_not_raise(self):
+        p = Path("a/b/c")
+        self.assertEqual(p.posix_path(), "a/b/c")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi, This PR is all Clarisse related. Also generic gpath stuff was changed, but that's not being used outside Clarisse either at the moment.

The purpose of this work is to change behavior of windows path resolution.
Previously, paths were "Linuxified" within Clarisse using it's API by way of a prerender script.
The problem was that connections between different referenced files (for example - rocks as input to a scatterer from a referenced rock library) would be broken on file open. Fixing the referenced paths after the scene opens does not reconnect. Therefore, the scene needs to have all valid path references before its opened, and for this reason, we write out linuxified copies of the scene file and all project files it references. The prerender script is still used for validations and so on, but it no longer manipulates paths.