### PR TITLE
adds braces to quote string in tcl expr

### DIFF
--- a/conductor/lib/nuke_utils.py
+++ b/conductor/lib/nuke_utils.py
@@ -3,7 +3,6 @@ import os
 import re
 
 import nuke
-
 from conductor.lib import package_utils
 
 logger = logging.getLogger(__name__)
@@ -156,7 +155,7 @@ def resolve_knob_path(knob):
     '''
     raw_value = knob.value()
     logger.debug("Resolving tcl expressions (if any) on %s value: %r", knob.fullyQualifiedName(), raw_value)
-    path = nuke.runIn(knob.node().fullName(), "nuke.tcl('return %s')" % raw_value.replace("'", "\\'"))
+    path = nuke.runIn(knob.node().fullName(), "nuke.tcl('return {%s}')" % raw_value.replace("'", "\\'"))
 
     # If the path is empty/none, simply return.  no further processing necessary
     if not path:


### PR DESCRIPTION
Customer had failure to submit nuke job with path containing spaces.

```Traceback (most recent call last):
  File "/Applications/Conductor.app/Contents/MacOS/conductor/submitter.py", line 809, in on_ui_submit_pbtn_clicked
    data = self.runPreSubmission()
  File "/Applications/Conductor.app/Contents/MacOS/conductor/submitter_nuke.py", line 278, in runPreSubmission
    raw_dependencies = self.collectDependencies(write_nodes, views)
  File "/Applications/Conductor.app/Contents/MacOS/conductor/submitter_nuke.py", line 202, in collectDependencies
    dependencies = nuke_utils.collect_dependencies(write_nodes, views, dependency_knobs)
  File "/Applications/Conductor.app/Contents/MacOS/conductor/lib/nuke_utils.py", line 127, in collect_dependencies
    path = resolve_knob_path(knob)
  File "/Applications/Conductor.app/Contents/MacOS/conductor/lib/nuke_utils.py", line 159, in resolve_knob_path
    path = nuke.runIn(knob.node().fullName(), "nuke.tcl('return %s')" % raw_value.replace("'", "\\'"))
  File "<string>", line 1, in <module>
RuntimeError: bad option "/Users/rlarroque/Documents/maya/projects/LIGHT_RIG_AGORA/images/CHA_BEAUTY/light": must be -code, -errorcode, or -errorinfo```
