### PR TITLE
puts companion in own folder and make a link in the bin directory

### DIFF
--- a/installers/rpm/build.sh
+++ b/installers/rpm/build.sh
@@ -44,7 +44,9 @@ cp -r ${SRC_DIR}/bin \
 
 if [ $with_client = true ]; then
     DESKTOP_CLIENT_DIR=/artifacts/build/dc/linux64
-    cp -r  ${DESKTOP_CLIENT_DIR}/* ${RPM_BUILDROOT}/opt/conductor
+    mkdir -p ${RPM_BUILDROOT}/opt/conductor/companion
+    cp -r  ${DESKTOP_CLIENT_DIR}/* ${RPM_BUILDROOT}/opt/conductor/companion/
+    ln -s ${RPM_BUILDROOT}/opt/conductor/companion/conductor-companion ${RPM_BUILDROOT}/opt/conductor/bin/conductor-companion
 fi
 
 cp conductor.spec ${BUILD_DIR}/rpm/SPECS


### PR DESCRIPTION
In order to make the companion app appear in the path on Linux, put a symlink in /opt/conductor/bin 