### PR TITLE
encode error message in maya dep scraper

### DIFF
--- a/conductor/lib/file_utils.py
+++ b/conductor/lib/file_utils.py
@@ -95,8 +95,9 @@ def process_dependencies(paths):
             process_upload_filepath(path)
             dependencies[path] = None
         except exceptions.InvalidPathException as e:
-            logger.debug("%s", e)
-            dependencies[path] = e.message.encode('utf-8')
+            msg = e.message.encode('utf-8')
+            logger.debug("%s", msg)
+            dependencies[path] = msg
 
     return dependencies
 

--- a/conductor/lib/file_utils.py
+++ b/conductor/lib/file_utils.py
@@ -96,7 +96,7 @@ def process_dependencies(paths):
             dependencies[path] = None
         except exceptions.InvalidPathException as e:
             logger.debug("%s", e)
-            dependencies[path] = str(e)
+            dependencies[path] = e.message.encode('utf-8')
 
     return dependencies
 

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -4,8 +4,8 @@
 """
 
 import unittest
-
 import conductor.lib.file_utils as futil
+import logging
 
 
 class ProcessDependenciesTest(unittest.TestCase):
@@ -15,6 +15,10 @@ class ProcessDependenciesTest(unittest.TestCase):
         self.assertTrue("/path/to/filename.txt" in deps)
 
     def test_it_encodes_unicode_chars_in_error_message(self):
+        # make sure logging is triggered as it should also encode unicode.
+        logger = logging.getLogger("conductor")
+        logger.setLevel("DEBUG")
+
         paths = [u"/path/to/\u0123/name.txt"]
         deps = futil.process_dependencies(paths)
         self.assertTrue(u"/path/to/\u0123/name.txt" in deps)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,27 @@
+""" test file_utils
+
+   isort:skip_file
+"""
+
+import unittest
+
+import conductor.lib.file_utils as futil
+
+
+class ProcessDependenciesTest(unittest.TestCase):
+    def test_regular_filename(self):
+        paths = ["/path/to/filename.txt"]
+        deps = futil.process_dependencies(paths)
+        self.assertTrue("/path/to/filename.txt" in deps)
+
+    def test_it_encodes_unicode_chars_in_error_message(self):
+        paths = [u"/path/to/\u0123/name.txt"]
+        deps = futil.process_dependencies(paths)
+        self.assertTrue(u"/path/to/\u0123/name.txt" in deps)
+        self.assertTrue(
+            "/path/to/\xc4\xa3/name.txt" in deps[u"/path/to/\u0123/name.txt"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The result of process_dependencies() is an object where keys are paths and values are possibly error messages. If those error messages contain unicode characters (which could be one of the reasons for the error in the first place) then the error message cannot be cast to str() and printed, so the customer will not be told what filename caused the error. The message must be UTF8 encoded.