### PR TITLE
workaround for RfM 23.3 bug

### DIFF
--- a/conductor/lib/maya_utils.py
+++ b/conductor/lib/maya_utils.py
@@ -480,9 +480,16 @@ def collect_dependencies(node_attrs):
     '''
     assert isinstance(node_attrs, dict), "node_attrs arg must be a dict. Got %s" % type(node_attrs)
 
+    # TODO: Temporary hack to work around renderman 23.3 bug.
+    # Record the active renderer so that we can restore it after making this cmds.file call
+    active_renderer = get_active_renderer()
     # Note that this command will often times return filepaths with an ending "/" on it for some reason. Strip this out at the end of the function
     dependencies = cmds.file(query=True, list=True, withoutCopyNumber=True) or []
+    # Strip errant dependences (another part of the renderman bug above).
+    dependencies = [path for path in dependencies if not path.endswith('_<user')]
     logger.debug("maya scene base dependencies: %s", dependencies)
+    # Reinstate active renderer
+    cmds.setAttr("defaultRenderGlobals.currentRenderer", active_renderer, type="string")
 
     # collect a list of ass filepaths that we can process at one time at the end of function, rather
     # than on a per node/attr basis (much slower)


### PR DESCRIPTION
**UPDATE** It's been 2 months since first reporting the bug to Pixar. Still no fix. Let's merge. Hopefully we can remove at some point.

~~This PR is not intended for merging into master, but rather provide an avenue for renderman customers who are blocked by an apparent Rfm 23.3 bug.~~

## Bug report

When calling `cmds.file(query=True, list=True)`, there are two peculiar things that happen:
1. The returned value (a list) now includes a nonsensical path ( ending with the string `_<user` ).
2. Regardless of what the active renderer had been set to (e.g. `Maya Software` or `Arnold`), it is now set to `RenderMan`.

### Repro

1. Open a fresh maya scene.

2. Load the `RenderMan_for_Maya` plugin.

3. Ensure that the global render settings have `MayaSoftware` chosen as the active renderer.

4. Execute python:    (Project set as `/tmp` )
  ```python 
cmds.file(query=True, list=True)
# Result: [u'/tmp/untitled', u'/tmp/UNTITLED_<user'] #
```


5. Close/reopen the global render settings window.
    Notice that the tab next to the *Common* tab is now *RenderMan* (as opposed to *Maya Software*).
    Querying for the active renderer through python also confirms this change:
  ```python
cmds.getAttr("defaultRenderGlobals.currentRenderer")
# Result: renderman #
```
