### PR TITLE
[BT-536] file api refactor multipart and tcp connection pooling

### DIFF
--- a/conductor/lib/api_client.py
+++ b/conductor/lib/api_client.py
@@ -27,7 +27,6 @@ CONNECTION_EXCEPTIONS = (requests.exceptions.HTTPError,
 
 
 class ApiClient():
-
     http_verbs = ["PUT", "POST", "GET", "DELETE", "HEAD", "PATCH"]
 
     def __init__(self):
@@ -35,10 +34,13 @@ class ApiClient():
         self._session = requests.Session()
 
     def _make_request(self, verb, conductor_url, headers, params, data, raise_on_error=True):
-        response = requests.request(verb, conductor_url,
-                                    headers=headers,
-                                    params=params,
-                                    data=data)
+        response = self._session.request(
+            method=verb,
+            url=conductor_url,
+            headers=headers,
+            params=params,
+            data=data
+        )
 
         logger.debug("verb: %s", verb)
         logger.debug("conductor_url: %s", conductor_url)

--- a/conductor/lib/api_client.py
+++ b/conductor/lib/api_client.py
@@ -66,7 +66,13 @@ class ApiClient():
                               remove_headers_list=None, raise_on_error=True, tries=5):
 
         """
-        Primarily used to removed enforced headers by requests.Request.
+        Primarily used to removed enforced headers by requests.Request. Requests 2.x will add
+        Transfer-Encoding: chunked with file like object that is 0 bytes, causing s3 failures (501)
+        - https://github.com/psf/requests/issues/4215#issuecomment-319521235
+
+        To get around this bug make_prepared_request has functionality to remove the enforced header that would
+        occur when using requests.request(...). Requests 3.x resolves this issue, when client is built to use
+        Requests 3.x this function can be deprecated.
 
         args:
             verb: (str) of HTTP verbs

--- a/conductor/lib/api_client.py
+++ b/conductor/lib/api_client.py
@@ -62,7 +62,7 @@ class ApiClient():
 #         logger.debug('response.text is: %s', response.text)
         return response
 
-    def make_prepared_request(self, verb, url, headers=None, params=None, json=None, data=None, stream=True,
+    def make_prepared_request(self, verb, url, headers=None, params=None, json=None, data=None, stream=False,
                               remove_headers_list=None, raise_on_error=True, tries=5):
 
         """

--- a/conductor/lib/api_client.py
+++ b/conductor/lib/api_client.py
@@ -64,7 +64,7 @@ class ApiClient():
                               remove_headers_list=None, raise_on_error=True, tries=5):
 
         """
-        Primarily used to removed enforced headers by requests.request.
+        Primarily used to removed enforced headers by requests.Request.
 
         args:
             verb: (str) of HTTP verbs
@@ -93,12 +93,13 @@ class ApiClient():
 
         if remove_headers_list:
             for header in remove_headers_list:
-                if header in prepped.headers:
-                    del prepped.headers[header]
+                prepped.headers.pop(header, None)
 
         # Create a retry wrapper function
-        retry_wrapper = common.DecRetry(retry_exceptions=CONNECTION_EXCEPTIONS,
-                                        tries=tries)
+        retry_wrapper = common.DecRetry(
+            retry_exceptions=CONNECTION_EXCEPTIONS,
+            tries=tries
+        )
 
         # wrap the request function with the retry wrapper
         wrapped_func = retry_wrapper(self._session.send)

--- a/conductor/lib/api_client.py
+++ b/conductor/lib/api_client.py
@@ -7,8 +7,6 @@ import time
 import urlparse
 import jwt
 
-from requests import Request, Session
-
 from conductor import CONFIG
 from conductor.lib import common, auth
 
@@ -34,7 +32,7 @@ class ApiClient():
 
     def __init__(self):
         logger.debug('')
-        self._session = Session()
+        self._session = requests.Session()
 
     def _make_request(self, verb, conductor_url, headers, params, data, raise_on_error=True):
         response = requests.request(verb, conductor_url,
@@ -83,7 +81,7 @@ class ApiClient():
         return: request.Response
         """
 
-        req = Request(
+        req = requests.Request(
             method=verb,
             url=url,
             headers=headers,

--- a/conductor/lib/uploader.py
+++ b/conductor/lib/uploader.py
@@ -349,7 +349,6 @@ class UploadWorker(worker.ThreadWorker):
                     headers=headers,
                     params=None,
                     data=fh,
-                    stream=True,
                     tries=1,
                     # s3 will return a 501 if the Transfer-Encoding header exists
                     remove_headers_list=["Transfer-Encoding"],
@@ -439,7 +438,6 @@ class UploadWorker(worker.ThreadWorker):
                 },
                 params=None,
                 data=data,
-                stream=True,
                 tries=1,
                 remove_headers_list=["Transfer-Encoding"]  # s3 will return a 501 if the Transfer-Encoding header exists
             )

--- a/conductor/lib/uploader.py
+++ b/conductor/lib/uploader.py
@@ -342,8 +342,7 @@ class UploadWorker(worker.ThreadWorker):
             }
 
             with open(filename, 'rb') as fh:
-                # TODO: update make_request to be flexible with auth headers
-                # TODO: support chunked or streamed data
+                # TODO: support chunked
                 self.api_client.make_prepared_request(
                     verb="PUT",
                     url=upload_url,

--- a/conductor/lib/uploader.py
+++ b/conductor/lib/uploader.py
@@ -151,7 +151,7 @@ class MD5OutputWorker(worker.ThreadWorker):
 class HttpBatchWorker(worker.ThreadWorker):
     '''
     This worker receives a batched list of files (path, hash, size) and makes an batched http api call
-    which returns a mixture of multipartURLs (if any) and singlePartURLs (if any).
+    which returns a mixture of multiPartURLs (if any) and singlePartURLs (if any).
 
     in_queue: [
         {
@@ -166,7 +166,7 @@ class HttpBatchWorker(worker.ThreadWorker):
         },
     ]
     out_queue: {
-        "multipartURLs": [
+        "multiPartURLs": [
             {
                 "uploadID: "FqzC8mkGxTsLzAR5CuBv771an9D5WLthLbl_xFKCaqKEdqf",
                 "filePath: "/linux64/bin/animate",
@@ -259,7 +259,7 @@ class FileStatWorker(worker.ThreadWorker):
             self.put_job((path, byte_count, upload_url, SINGLEPART))
 
         # iterate through multipart
-        for multipart_upload in job.get("multipartURLs", []):
+        for multipart_upload in job.get("multiPartURLs", []):
             path = multipart_upload["filePath"]
             if not os.path.isfile(path):
                 return None

--- a/conductor/lib/uploader.py
+++ b/conductor/lib/uploader.py
@@ -16,6 +16,9 @@ LOG_FORMATTER = logging.Formatter('%(asctime)s  %(name)s%(levelname)9s  %(thread
 
 logger = logging.getLogger(__name__)
 
+PRESIGNED = "presigned"
+MULTIPART = "multipart"
+
 
 class MD5Worker(worker.ThreadWorker):
     '''
@@ -46,7 +49,8 @@ class MD5Worker(worker.ThreadWorker):
                 logger.error(message)
                 raise Exception(message)
         self.metric_store.set_dict('file_md5s', filename, current_md5)
-        return (filename, current_md5)
+        size_bytes = os.path.getsize(filename)
+        return (filename, current_md5, size_bytes)
 
     def get_md5(self, filepath):
         '''
@@ -93,7 +97,7 @@ class MD5OutputWorker(worker.ThreadWorker):
         super(MD5OutputWorker, self).__init__(*args, **kwargs)
         self.batch_size = 20  # the controlls the batch size for http get_signed_urls
         self.wait_time = 1
-        self.batch = {}
+        self.batch = []
 
     def check_for_poison_pill(self, job):
         ''' we need to make sure we ship the last batch before we terminate '''
@@ -108,7 +112,7 @@ class MD5OutputWorker(worker.ThreadWorker):
         if self.batch:
             logger.debug('sending batch: %s', self.batch)
             self.put_job(self.batch)
-            self.batch = {}
+            self.batch = []
 
     def target(self, thread_int):
 
@@ -119,8 +123,12 @@ class MD5OutputWorker(worker.ThreadWorker):
 
                 self.check_for_poison_pill(file_md5_tuple)
 
-                # add (filepath: md5) to the batch dict
-                self.batch[file_md5_tuple[0]] = file_md5_tuple[1]
+                # add file info to the batch list
+                self.batch.append({
+                    'path': file_md5_tuple[0],
+                    'hash': file_md5_tuple[1],
+                    'size': file_md5_tuple[2],
+                })
 
                 # if the batch is self.batch_size, ship it
                 if len(self.batch) == self.batch_size:
@@ -142,11 +150,44 @@ class MD5OutputWorker(worker.ThreadWorker):
 
 class HttpBatchWorker(worker.ThreadWorker):
     '''
-    This worker receives a batched dict of (filename: md5) pairs and makes a
-    batched http api call which returns a list of (filename: signed_upload_url)
-    of files that need to be uploaded.
+    This worker receives a batched list of files (path, hash, size) and makes an batched http api call
+    which returns a mixture of multipartURLs (if any) and preSignedURLs (if any).
 
-    Each item in the return list is added to the out_queue.
+    in_queue: [
+        {
+            "path": "/linux64/bin/animate",
+            "hash": "c986fb5f1c9ccf47eecc645081e4b108",
+            "size": 2147483648
+        },
+        {
+            "path": "/linux64/bin/tiff2ps",
+            "hash": " fd27a8f925a72e788ea94997ca9a21ca",
+            "size": 123
+        },
+    ]
+    out_queue: {
+        "multipartURLs": [
+            {
+                "uploadID: "FqzC8mkGxTsLzAR5CuBv771an9D5WLthLbl_xFKCaqKEdqf",
+                "filePath: "/linux64/bin/animate",
+                "md5": " c986fb5f1c9ccf47eecc645081e4b108",
+                "partSize": "1073741824",
+                "parts: [
+                    {
+                        "partNumber": 1,
+                        "url: "https://www.signedurlexample.com/signature1"
+                    },
+                    {
+                        "partNumber": 2,
+                        "url: "https://www.signedurlexample.com/signature1"
+                    }
+                ]
+            }
+        ]
+        "preSignedURLs": {
+            "/linux64/bin/tiff2ps": "https://www.signedurlexample.com/signature2"
+        }
+    }
     '''
 
     def __init__(self, *args, **kwargs):
@@ -155,7 +196,7 @@ class HttpBatchWorker(worker.ThreadWorker):
         self.project = kwargs.get('project')
 
     def make_request(self, job):
-        uri_path = '/api/files/get_upload_urls'
+        uri_path = '/api/files/v2/get_upload_urls'
         headers = {'Content-Type': 'application/json'}
         data = {"upload_files": job,
                 "project": self.project}
@@ -180,12 +221,12 @@ class HttpBatchWorker(worker.ThreadWorker):
 
 
 '''
-This worker subscribes to a queue of (path,signed_upload_url) pairs.
+This worker subscribes to a queue of list of file uploads (multipart and presigned).
 
 For each item on the queue, it determines the size (in bytes) of the files to be
 uploaded, and aggregates the total size for all uploads.
 
-It then places the triplet (filepath, upload_url, byte_size) onto the out_queue
+It then places a tuple of (filepath, upload, type of upload(multipart or presigned)) onto the out_queue
 
 The bytes_to_upload arg is used to hold the aggregated size of all files that need
 to be uploaded. Note: This is stored as an [int] in order to pass it by
@@ -199,14 +240,14 @@ class FileStatWorker(worker.ThreadWorker):
 
     def do_work(self, job, thread_int):
         '''
-        Job is a dict of filepath: signed_upload_url pairs.
-        The FileStatWorker iterates through the dict.
-        For each item, it aggregates the filesize in bytes, and passes each
-        pair as a tuple to the UploadWorker queue.
+        Job is a list of file uploads (multipart and presigned) returned from File API.
+        The FileStatWorker iterates through the list.
+        For each item, it aggregates the filesize in bytes, and passes
+        the upload into the UploadWorker queue.
         '''
 
-        # iterate through a dict of (filepath: upload_url) pairs
-        for path, upload_url in job.iteritems():
+        # iterate through presigned urls
+        for path, upload_url in job.get("preSignedURLs", {}).iteritems():
             if not os.path.isfile(path):
                 return None
             # logger.debug('stat: %s', path)
@@ -215,7 +256,20 @@ class FileStatWorker(worker.ThreadWorker):
             self.metric_store.increment('bytes_to_upload', byte_count)
             self.metric_store.increment('num_files_to_upload')
 
-            self.put_job((path, upload_url))
+            self.put_job((path, upload_url, PRESIGNED))
+
+        # iterate through multipart
+        for multipart_upload in job.get("multipartURLs", {}).iteritems():
+            path = multipart_upload["filePath"]
+            if not os.path.isfile(path):
+                return None
+            # logger.debug('stat: %s', path)
+            byte_count = os.path.getsize(path)
+
+            self.metric_store.increment('bytes_to_upload', byte_count)
+            self.metric_store.increment('num_files_to_upload')
+
+            self.put_job((path, multipart_upload, MULTIPART))
 
         # make sure we return None, so no message is automatically added to the out_queue
         return None
@@ -223,8 +277,8 @@ class FileStatWorker(worker.ThreadWorker):
 
 class UploadWorker(worker.ThreadWorker):
     '''
-    This worker receives a (filepath: signed_upload_url) pair and performs an upload
-    of the specified file to the provided url.
+    This worker receives a either (filepath: signed_upload_url) pair or (filepath: multipart (dict)) and performs
+    an upload of the specified file to the provided url.
     '''
 
     def __init__(self, *args, **kwargs):
@@ -232,6 +286,7 @@ class UploadWorker(worker.ThreadWorker):
         self.chunk_size = 1048576  # 1M
         self.report_size = 10485760  # 10M
         self.api_client = api_client.ApiClient()
+        self.project = kwargs.get('project')
 
     def chunked_reader(self, filename):
         with open(filename, 'rb') as fp:
@@ -248,10 +303,18 @@ class UploadWorker(worker.ThreadWorker):
 
     def do_work(self, job, thread_int):
         filename = job[0]
-        upload_url = job[1]
+        upload = job[1]
+        upload_type = job[2]
+
         md5 = self.metric_store.get_dict('file_md5s', filename)
+
         try:
-            return self.do_upload(upload_url, filename, md5)
+            if upload_type == PRESIGNED:
+                return self.do_upload(upload, filename, md5)
+            elif upload_type == MULTIPART:
+                return self.do_multipart_upload(job, filename, md5)
+
+            raise Exception("upload_type neither %s or %s", PRESIGNED, MULTIPART)
         except:
             logger.exception("Failed to upload file: %s because of:\n", filename)
             real_md5 = common.get_base64_md5(filename)
@@ -295,6 +358,66 @@ class UploadWorker(worker.ThreadWorker):
                                                 tries=1,
                                                 use_api_key=True)
 
+    @common.DecRetry(retry_exceptions=api_client.CONNECTION_EXCEPTIONS, tries=5)
+    def do_multipart_upload(self, job, filename, md5):
+        """
+        Files will be split into partSize returned by the FileAPI and hydrated in S3
+        once all parts are uploaded. On successful part upload to S3, it will return an ETag. This value must be
+        tracked along with the part number in order to complete and hydrate the file in S3.
+        """
+
+        uploads = []
+        complete_payload = {
+            "uploadID": job["uploadID"],
+            "hash": md5,
+            "completedParts": [],
+            "project": self.project
+        }
+
+        # iterate over parts and upload
+        for part in job["parts"]:
+            resp = self._do_part_upload(
+                upload_url=part["url"],
+                filename=filename,
+                part_number=part["partNumber"],
+                part_size=job["partSize"]
+            )
+
+            uploads.append(resp)
+            completed_part = {
+                "partNumber": part["partNumber"],
+                "etag": resp.headers['ETag'].strip('"')
+            }
+            complete_payload["completedParts"].append(completed_part)
+
+        # Complete multipart upload in order to hydrate file in S3 for availability
+        uri_path = '/api/files/v2/complete_multipart'
+        headers = {'Content-Type': 'application/json'}
+        self.api_client.make_request(uri_path=uri_path,
+                                     verb='POST',
+                                     headers=headers,
+                                     data=json.dumps(complete_payload),
+                                     raise_on_error=True,
+                                     use_api_key=True)
+
+        return uploads
+
+    def _do_part_upload(self, upload_url, filename, part_number, part_size):
+        with open(filename, 'rb') as fh:
+            # seek to the correct part position
+            start = (part_number - 1) * part_size
+            fh.seek(start)
+
+            # read up to MULTIPART_SIZE
+            data = fh.read(part_size)
+
+            # upload part
+            return self.api_client._make_request(verb="PUT",
+                                                 conductor_url=upload_url,
+                                                 headers={},
+                                                 params=None,
+                                                 data=data)
+
 
 class Uploader(object):
 
@@ -333,7 +456,7 @@ class Uploader(object):
                 (HttpBatchWorker, [], {'thread_count': self.args['thread_count'],
                                        "project": project}),
                 (FileStatWorker, [], {'thread_count': 1}),
-                (UploadWorker, [], {'thread_count': self.args['thread_count']}),
+                (UploadWorker, [], {'thread_count': self.args['thread_count'], 'project': project}),
             ]
 
         manager = worker.JobManager(job_description)

--- a/conductor/lib/uploader.py
+++ b/conductor/lib/uploader.py
@@ -350,9 +350,13 @@ class UploadWorker(worker.ThreadWorker):
                     headers=headers,
                     params=None,
                     data=fh,
+                    tries=1,
                     # s3 will return a 501 if the Transfer-Encoding header exists
-                    remove_headers_list=["Transfer-Encoding"]
+                    remove_headers_list=["Transfer-Encoding"],
                 )
+
+                # report upload progress
+                self.metric_store.increment('bytes_uploaded', file_size, filename)
 
                 return
 
@@ -431,8 +435,12 @@ class UploadWorker(worker.ThreadWorker):
                 },
                 params=None,
                 data=data,
+                tries=1,
                 remove_headers_list=["Transfer-Encoding"]  # s3 will return a 501 if the Transfer-Encoding header exists
             )
+
+            # report upload progress
+            self.metric_store.increment('bytes_uploaded', content_length, filename)
 
             return response.headers
 

--- a/conductor/lib/uploader.py
+++ b/conductor/lib/uploader.py
@@ -360,9 +360,6 @@ class UploadWorker(worker.ThreadWorker):
 
                 # report upload progress
                 self.metric_store.increment('bytes_uploaded', file_size, filename)
-
-                return
-
         else:
             headers = {'Content-MD5': md5,
                        'Content-Type': 'application/octet-stream'}
@@ -374,7 +371,6 @@ class UploadWorker(worker.ThreadWorker):
                                                 tries=1,
                                                 use_api_key=True)
 
-    @common.DecRetry(retry_exceptions=api_client.CONNECTION_EXCEPTIONS, tries=5)
     def do_multipart_upload(self, upload, filename, md5):
         """
         Files will be split into partSize returned by the FileAPI and hydrated
@@ -418,6 +414,7 @@ class UploadWorker(worker.ThreadWorker):
 
         return uploads
 
+    @common.DecRetry(retry_exceptions=api_client.CONNECTION_EXCEPTIONS, tries=5)
     def _do_multipart_upload(self, upload_url, filename, part_number, part_size):
         with open(filename, 'rb') as fh:
             # seek to the correct part position
@@ -489,7 +486,7 @@ class Uploader(object):
                 (HttpBatchWorker, [], {'thread_count': self.args['thread_count'],
                                        "project": project}),
                 (FileStatWorker, [], {'thread_count': 1}),
-                (UploadWorker, [], {'thread_count': self.args['thread_count'], 'project': project}),
+                (UploadWorker, [], {'thread_count': self.args['thread_count']}),
             ]
 
         manager = worker.JobManager(job_description)

--- a/conductor/lib/uploader.py
+++ b/conductor/lib/uploader.py
@@ -391,7 +391,7 @@ class UploadWorker(worker.ThreadWorker):
 
         # iterate over parts and upload
         for part in upload["parts"]:
-            resp_headers = self._do_part_upload(
+            resp_headers = self._do_multipart_upload(
                 upload_url=part["url"],
                 filename=filename,
                 part_number=part["partNumber"],
@@ -418,7 +418,7 @@ class UploadWorker(worker.ThreadWorker):
 
         return uploads
 
-    def _do_part_upload(self, upload_url, filename, part_number, part_size):
+    def _do_multipart_upload(self, upload_url, filename, part_number, part_size):
         with open(filename, 'rb') as fh:
             # seek to the correct part position
             start = (part_number - 1) * part_size


### PR DESCRIPTION
Related to: https://github.com/AtomicConductor/conductor_ae/pull/715, https://github.com/AtomicConductor/file-api/pull/24

# Uploader
- Update request payload to v2 signing url (path, hash, size)
- Update tuple output queue information for FileStatWorker (normal presigned url or multipart)
- Fix AWS reporting on upload progress to conductor api/dashboard, cannot use chunkreader method due to it needing a len() function from the generator. Since the default prepared_request is using a [stream](https://github.com/AtomicConductor/conductor_client/compare/BT-536-file-api-refactor-multipart) it will not load the entire file into memory.
- Multipart upload partsize is controlled by File-API allowing backend to adjust sizes as needed.
- FileStatWorker uses HttpBatchWorker file_size response instead of additional os.stat since this is being done prior in the MD5Worker.

# API Client
- Use requests.Session object so that tcp connections are re-used when the same destination host and port are being accessed. This should help speed up uploads since the 3 way handshake will not occur everytime.
- add prepared_request method, since s3 will return a 501 with the Transfer-Encoding header, need to use prepared request to remove header from being added( default requests.Request will do that). Add same retry logic as `make_request`