### PR TITLE
lock/checkout specific commit for osslsigncode

### DIFF
--- a/installers/build/Dockerfile.certify
+++ b/installers/build/Dockerfile.certify
@@ -11,6 +11,7 @@ RUN apt-get update && \
                        
 RUN git clone https://github.com/mtrojnar/osslsigncode.git /tmp/osslsigncode
 
+# use specific git sha since v2.1 or master can be potentially broken at compile-time
 RUN cd /tmp/osslsigncode && \
        git checkout 1670a07089febfb5546880e0df916f3f196156ce && \
        ./autogen.sh && \

--- a/installers/build/Dockerfile.certify
+++ b/installers/build/Dockerfile.certify
@@ -12,6 +12,7 @@ RUN apt-get update && \
 RUN git clone https://github.com/mtrojnar/osslsigncode.git /tmp/osslsigncode
 
 RUN cd /tmp/osslsigncode && \
+       git checkout 1670a07089febfb5546880e0df916f3f196156ce && \
        ./autogen.sh && \
        ./configure && \
        make && \


### PR DESCRIPTION
Resolves in certify step:
https://app.codeship.com/projects/291182/builds/5963ecd0-96a8-4568-a07d-b58c9cb429eb?step=serial_(2)_Certify
```
2020-06-17 14:29:17
make  all-am
2020-06-17 14:29:17
make[1]: Entering directory '/tmp/osslsigncode'
gcc -DHAVE_CONFIG_H -I.      -I/usr/include/x86_64-linux-gnu -g -O2 -MT osslsigncode.o -MD -MP -MF .deps/osslsigncode.Tpo -c -o osslsigncode.o osslsigncode.c
2020-06-17 14:29:17
osslsigncode.c: In function 'ASN1_GetTimeT':
2020-06-17 14:29:17
osslsigncode.c:1686:6: warning: implicit declaration of function 'ASN1_TIME_to_tm' [-Wimplicit-function-declaration]
  if (ASN1_TIME_to_tm(s, &tm)) {
      ^~~~~~~~~~~~~~~
2020-06-17 14:29:18
mv -f .deps/osslsigncode.Tpo .deps/osslsigncode.Po
2020-06-17 14:29:18
gcc   -I/usr/include/x86_64-linux-gnu -g -O2   -o osslsigncode osslsigncode.o  -lcrypto  -ldl -lcurl 
2020-06-17 14:29:18
osslsigncode.o: In function `ASN1_GetTimeT':
/tmp/osslsigncode/osslsigncode.c:1686: undefined reference to `ASN1_TIME_to_tm'
/tmp/osslsigncode/osslsigncode.c:1686: undefined reference to `ASN1_TIME_to_tm'
2020-06-17 14:29:18
collect2: error: ld returned 1 exit status
2020-06-17 14:29:18
Makefile:397: recipe for target 'osslsigncode' failed
2020-06-17 14:29:18
make[1]: Leaving directory '/tmp/osslsigncode'
2020-06-17 14:29:18
make[1]: *** [osslsigncode] Error 1
2020-06-17 14:29:18
make: *** [all] Error 2
2020-06-17 14:29:18
Makefile:301: recipe for target 'all' failed
2020-06-17 14:29:19
Removing intermediate container 9c04ca774d7e
2020-06-17 14:29:19
Failed image build for "certify" service
```