### PR TITLE
reverse the order of instance-types populated in submitter combobox

### DIFF
--- a/conductor/submitter.py
+++ b/conductor/submitter.py
@@ -491,7 +491,7 @@ class ConductorSubmitter(QtWidgets.QMainWindow):
         '''
 
         self.ui_instance_type_cmbx.clear()
-        for instance_type in sorted(self._instance_types.values(), key=operator.itemgetter("cores", "memory"), reverse=True):
+        for instance_type in sorted(self._instance_types.values(), key=operator.itemgetter("cores", "memory")):
             self.ui_instance_type_cmbx.addItem(instance_type['description'], userData=instance_type)
 
     def populateGpuCmbx(self):


### PR DESCRIPTION
The lower core instances are now at the top.   And as a side effect, the default instance type is now 2 cores (as opposed to e.g. 160 )

![image](https://user-images.githubusercontent.com/10409070/95415378-f4597080-08e4-11eb-835a-45dfa4a9a95d.png)

