### PR TITLE
[bugfix] nuke output path  (Windows slashes)

### DIFF
--- a/conductor/lib/nuke_utils.py
+++ b/conductor/lib/nuke_utils.py
@@ -167,8 +167,12 @@ def resolve_knob_path(knob):
         # Join the relative path with the nuke script directory
         path = os.path.join(nuke.script_directory(), path)
 
-    # Resolve any ellipses in the path (e.g. ../../  ). Unfortunately this also normpaths it, which may lead to some fallout/bugs
-    path = os.path.abspath(path)
+    # Resolve any ellipses in the path (e.g. ../../  ).
+    # Unfortunately this also normpaths it (which will change any forward slashes to backslashes
+    # if on Windows). So we perform a secondary hack to force-replace backslashes.  This may have
+    # unintended consequences (e.g. is there a case where we need/want to preserve backslashes on
+    # linux?)
+    path = os.path.abspath(path).replace('\\', "/")
 
     logger.debug("Resolved to: %s", path)
     return path


### PR DESCRIPTION
This resolves a bug where users submitting nuke jobs that use Windows UNC paths for their output paths we're getting improperly formatted  (backslash vs forwards slash).